### PR TITLE
Update README.md

### DIFF
--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -102,7 +102,7 @@ An `Offering` is used by the PFI to describe a currency pair they have to _offer
 | `payoutCurrency`          | [`CurrencyDetails`](#currencydetails)                                                                    | Y        | Details about the currency that the PFI is selling.                                                                                  |
 | `payinMethods`            | [`PaymentMethod[]`](#paymentmethod)                                                                      | Y        | A list of payment methods the counterparty (Alice) can choose to send payment to the PFI from in order to qualify for this offering. |
 | `payoutMethods`           | [`PaymentMethod[]`](#paymentmethod)                                                                      | Y        | A list of payment methods the counterparty (Alice) can choose to receive payment from the PFI in order to qualify for this offering. |
-| `requiredClaims`          | [`PresentationDefinitionV2`](https://identity.foundation/presentation-exchange/#presentation-definition) | Y        | Articulates the claim(s) required when submitting an RFQ for this offering.                                                          |
+| `requiredClaims`          | [`PresentationDefinitionV2`](https://identity.foundation/presentation-exchange/#presentation-definition) | N        | Articulates the claim(s) required when submitting an RFQ for this offering.                                                          |
 
 #### `CurrencyDetails`
 | field          | data type | required | description                                            |


### PR DESCRIPTION
Required claims is nullable because a PFI could choose to require zero information.

It's already not required by the json schema :) 

closes #213 