### PR TITLE
Fold paymentInstructions inside payin and payout

### DIFF
--- a/hosted/json-schemas/quote.schema.json
+++ b/hosted/json-schemas/quote.schema.json
@@ -17,6 +17,9 @@
         "fee": {
           "$ref": "definitions.json#/definitions/decimalString",
           "description": "The amount paid in fees"
+        },
+        "paymentInstruction": {
+          "$ref": "#/definitions/PaymentInstruction"
         }
       },
       "required": ["currencyCode", "amount"]
@@ -34,18 +37,6 @@
           "description": "Instruction on how Alice can pay PFI, or how Alice can be paid by the PFI"
         }
       }
-    },
-    "PaymentInstructions": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "payin": {
-          "$ref": "#/definitions/PaymentInstruction"
-        },
-        "payout": {
-          "$ref": "#/definitions/PaymentInstruction"
-        }
-      }
     }
   },
   "type": "object",
@@ -60,9 +51,6 @@
     },
     "payout": {
       "$ref": "#/definitions/QuoteDetails"
-    },
-    "paymentInstructions": {
-      "$ref": "#/definitions/PaymentInstructions"
     }
   },
   "required": ["expiresAt", "payin", "payout"]

--- a/hosted/test-vectors/protocol/vectors/parse-quote.json
+++ b/hosted/test-vectors/protocol/vectors/parse-quote.json
@@ -1,38 +1,36 @@
 {
   "description": "Quote parses from string",
-  "input": "{\"metadata\":{\"exchangeId\":\"rfq_01hkx78yxffp2b8z72zagwk81f\",\"from\":\"did:key:z6MkpkqjLNUHHazoqP1LMBuVLRTn8qXcUpqcnE5wwcgguU5p\",\"to\":\"did:ex:pfi\",\"kind\":\"quote\",\"id\":\"quote_01hkx78yxffp2b8z72zdmjez7q\",\"createdAt\":\"2024-01-11T21:36:27.055Z\"},\"data\":{\"expiresAt\":\"2024-01-11T21:36:27.055Z\",\"payin\":{\"currencyCode\":\"BTC\",\"amount\":\"0.01\",\"fee\":\"0.0001\"},\"payout\":{\"currencyCode\":\"USD\",\"amount\":\"1000.00\"},\"paymentInstructions\":{\"payin\":{\"link\":\"tbdex.io/example\",\"instruction\":\"Fake instruction\"},\"payout\":{\"link\":\"tbdex.io/example\",\"instruction\":\"Fake instruction\"}}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BrcWpMTlVISGF6b3FQMUxNQnVWTFJUbjhxWGNVcHFjbkU1d3djZ2d1VTVwI3o2TWtwa3FqTE5VSEhhem9xUDFMTUJ1VkxSVG44cVhjVXBxY25FNXd3Y2dndVU1cCJ9..jb3LxwUAJFHcFXtXtJy8FatIQ1Sz09e5RyBkSCELHhY9Kj3eVjgI4f2USCEATWvQ7oyZJSTyTpeBbBQpSE0QDA\"}",
+  "input": "{\"metadata\":{\"exchangeId\":\"rfq_01hm02j3bdf25rx1ahkx3h653v\",\"from\":\"did:key:z6MkfZVwW9oZug6SVdMVWNEndLf4rFcrxRVzhteAGRVF8ynJ\",\"to\":\"did:ex:pfi\",\"kind\":\"quote\",\"id\":\"quote_01hm02j3bdf25rx1ahm11dkp4v\",\"createdAt\":\"2024-01-13T00:11:46.925Z\"},\"data\":{\"expiresAt\":\"2024-01-13T00:11:46.925Z\",\"payin\":{\"currencyCode\":\"BTC\",\"amount\":\"0.01\",\"fee\":\"0.0001\",\"paymentInstruction\":{\"link\":\"tbdex.io/example\",\"instruction\":\"Fake instruction\"}},\"payout\":{\"currencyCode\":\"USD\",\"amount\":\"1000.00\",\"paymentInstruction\":{\"link\":\"tbdex.io/example\",\"instruction\":\"Fake instruction\"}}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2ZaVndXOW9adWc2U1ZkTVZXTkVuZExmNHJGY3J4UlZ6aHRlQUdSVkY4eW5KI3o2TWtmWlZ3VzlvWnVnNlNWZE1WV05FbmRMZjRyRmNyeFJWemh0ZUFHUlZGOHluSiJ9..e7R_CF3ocY8wVLDX9NkcG60Hw6C-G-9Xu4NmSuME4Qh7gvIdNzXrNbJ82hV_Y1MFJoy51rSnDvljGi3b5Tf8CA\"}",
   "output": {
     "metadata": {
-      "exchangeId": "rfq_01hkx78yxffp2b8z72zagwk81f",
-      "from": "did:key:z6MkpkqjLNUHHazoqP1LMBuVLRTn8qXcUpqcnE5wwcgguU5p",
+      "exchangeId": "rfq_01hm02j3bdf25rx1ahkx3h653v",
+      "from": "did:key:z6MkfZVwW9oZug6SVdMVWNEndLf4rFcrxRVzhteAGRVF8ynJ",
       "to": "did:ex:pfi",
       "kind": "quote",
-      "id": "quote_01hkx78yxffp2b8z72zdmjez7q",
-      "createdAt": "2024-01-11T21:36:27.055Z"
+      "id": "quote_01hm02j3bdf25rx1ahm11dkp4v",
+      "createdAt": "2024-01-13T00:11:46.925Z"
     },
     "data": {
-      "expiresAt": "2024-01-11T21:36:27.055Z",
+      "expiresAt": "2024-01-13T00:11:46.925Z",
       "payin": {
         "currencyCode": "BTC",
         "amount": "0.01",
-        "fee": "0.0001"
+        "fee": "0.0001",
+        "paymentInstruction": {
+          "link": "tbdex.io/example",
+          "instruction": "Fake instruction"
+        }
       },
       "payout": {
         "currencyCode": "USD",
-        "amount": "1000.00"
-      },
-      "paymentInstructions": {
-        "payin": {
-          "link": "tbdex.io/example",
-          "instruction": "Fake instruction"
-        },
-        "payout": {
+        "amount": "1000.00",
+        "paymentInstruction": {
           "link": "tbdex.io/example",
           "instruction": "Fake instruction"
         }
       }
     },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3BrcWpMTlVISGF6b3FQMUxNQnVWTFJUbjhxWGNVcHFjbkU1d3djZ2d1VTVwI3o2TWtwa3FqTE5VSEhhem9xUDFMTUJ1VkxSVG44cVhjVXBxY25FNXd3Y2dndVU1cCJ9..jb3LxwUAJFHcFXtXtJy8FatIQ1Sz09e5RyBkSCELHhY9Kj3eVjgI4f2USCEATWvQ7oyZJSTyTpeBbBQpSE0QDA"
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2ZaVndXOW9adWc2U1ZkTVZXTkVuZExmNHJGY3J4UlZ6aHRlQUdSVkY4eW5KI3o2TWtmWlZ3VzlvWnVnNlNWZE1WV05FbmRMZjRyRmNyeFJWemh0ZUFHUlZGOHluSiJ9..e7R_CF3ocY8wVLDX9NkcG60Hw6C-G-9Xu4NmSuME4Qh7gvIdNzXrNbJ82hV_Y1MFJoy51rSnDvljGi3b5Tf8CA"
   },
   "error": false
 }

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -40,7 +40,6 @@ Version: Draft
     - [`Close`](#close)
     - [`Quote`](#quote)
       - [`QuoteDetails`](#quotedetails)
-      - [`PaymentInstructions`](#paymentinstructions)
       - [`PaymentInstruction`](#paymentinstruction)
     - [`Order`](#order)
     - [`OrderStatus`](#orderstatus)
@@ -422,7 +421,6 @@ a `Close` can be sent by Alice _or_ the PFI as a reply to an RFQ or a Quote. It 
 | `expiresAt `          | datetime                                      | Y        | When this quote expires. Expressed as ISO8601                                                             |
 | `payin`               | [`QuoteDetails`](#quotedetails)               | Y        | the amount of _payin_ currency that the PFI will receive                                                  |
 | `payout`              | [`QuoteDetails`](#quotedetails)               | Y        | the amount of _payout_ currency that Alice will receive                                                   |
-| `paymentInstructions` | [`PaymentInstructions`](#paymentinstructions) | N        | Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link) |
 
 
 #### `QuoteDetails`
@@ -431,17 +429,12 @@ a `Close` can be sent by Alice _or_ the PFI as a reply to an RFQ or a Quote. It 
 | `currencyCode`   | string    | Y        | ISO 3166 currency code string                                    |
 | `amount` |      [`DecimalString`](#decimalstring)     | Y        | The amount of currency expressed in the smallest respective unit |
 | `fee`    | [`DecimalString`](#decimalstring)    | N        | The amount paid in fees                                          |
+| `paymentInstruction` | [`PaymentInstruction`](#paymentinstruction) | N        | Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link) |
 
 
 > [!NOTE]
 > 
 > Include a section that explains `fee`. Does `amount` _include_ `fee` or does `amount + fee = total`?
-
-#### `PaymentInstructions`
-| field    | data type                                   | required | description                                               |
-| -------- | ------------------------------------------- | -------- | --------------------------------------------------------- |
-| `payin`  | [`PaymentInstruction`](#paymentinstruction) | N        | Link or Instruction describing how to pay the PFI.        |
-| `payout` | [`PaymentInstruction`](#paymentinstruction) | N        | Link or Instruction describing how to get paid by the PFI |
 
 #### `PaymentInstruction`
 | field         | data type | required | description                                                               |


### PR DESCRIPTION
Addresses #201
Simplifies `Quote` structure by moving `paymentInstruction` into `payin`/`payout`

### Implementation PRs
Javascript: https://github.com/TBD54566975/tbdex-js/pull/140
Kotlin: https://github.com/TBD54566975/tbdex-kt/pull/136