### PR TITLE
Allow Offering.data.requiredClaims to be optional in JSON Schema

### DIFF
--- a/hosted/json-schemas/offering.schema.json
+++ b/hosted/json-schemas/offering.schema.json
@@ -77,7 +77,6 @@
     "payinCurrency",
     "payoutCurrency",
     "payinMethods",
-    "payoutMethods",
-    "requiredClaims"
+    "payoutMethods"
   ]
 }


### PR DESCRIPTION
As per spec. N denotes "Not required"

<img width="1243" alt="Screenshot 2024-01-19 at 4 27 37 PM" src="https://github.com/TBD54566975/tbdex/assets/74206001/1c9f784d-1e6c-4f2f-8ca7-29afc622b2bb">
