### PR TITLE
Strongly type sensitive data in RFQ

### DIFF
--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -281,7 +281,7 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 | `offeringId`   | string                                            | Y        | Offering for which Alice would like to get a quote                                                                          |
 | `payinAmount`  | [`DecimalString`](#decimalstring)                 | Y        | Amount of payin currency you want in exchange for payout currency                                                           |
 | `claims`       | string[]                                          | N        | An array of claims that fulfill the requirements declared in an [Offering](#offering). Excluded from the signature payload. |
-| `claimsHash`   | string                                            | Y        | A hash [digest](#digest) of `claims`                                                                                        |
+| `claimsHash`   | string                                            | N        | A hash [digest](#digest) of `claims`                                                                                        |
 | `payinMethod`  | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to send payin currency.                                                                        |
 | `payoutMethod` | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to receive payout currency.                                                                    |
 
@@ -297,7 +297,7 @@ For further information on supported hashing algorithms, please refer to [digest
 |----------------------|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | `kind`               | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)                                                             |
 | `paymentDetails`     | object    | N        | An object containing the properties defined in an Offering's `requiredPaymentDetails` json schema. Excluded from the signature payload. |
-| `paymentDetailsHash` | string    | Y        | A hash [digest](#digest)  of `paymentDetails`                                                                                           |
+| `paymentDetailsHash` | string    | N        | A hash [digest](#digest)  of `paymentDetails`                                                                                           |
 
 
 #### RFQ example


### PR DESCRIPTION
Previously, we considered the concept of a top-level `private` property in RFQ, which would contain the private data specified by the Offering, where corresponding `Rfq.data` would be hashed. This has proved to be complicated in design and implementation.

### Proposal
The potentially sensitive fields are `claims`, `payinMethod.paymentDetails`, and `payoutMethod.paymentDetails`. These fields will NEVER be part of the signed payload. In other words, when creating a signature for an RFQ, the sensitive fields are stripped from the payload and then signed.

We also add new required fields in the `Rfq.data`: `claimsHash`, `payinMethod.paymentDetailsHash`, and `payoutMethod.paymentDetailsHash`. As the name implies, these fields are a hash of their counterpart. The hashed fields ARE part of the signed payload, the same as other fields like `offeringId`, `payinAmount`, etc.

### TODO
- [ ] Update Test Vectors
- [ ] Javascript implementation
- [ ] Kotlin Implementation