### PR TITLE
Add Close.success to the protocol spec

### DIFF
--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -496,14 +496,14 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 
 > PFI -> Alice: "Can't fulfill what you sent me for whatever reason (e.g. RFQ is erroneous, don't have enough liquidity etc.)" or "Your exchange is completed"
 
-a `Close` can be sent by Alice _or_ the PFI as a reply to an RFQ or a Quote. It indicates a terminal state. No messages can be added to an exchange after a `Close`.
+A `Close` indicates a terminal state; no messages are valid after a `Close`. 
 
-| Field    | Data Type | Required | Description                                                  |
-| -------- | --------- | -------- | ------------------------------------------------------------ |
-| `reason` | string    | N        | an explanation of why the exchange is being closed/completed |
+| Field     | Data Type | Required | Description                                                  |
+| --------- | --------- | -------- | ------------------------------------------------------------ |
+| `reason`  | string    | N        | an explanation of why the exchange is being closed/completed |
+| `success` | boolean   | N        | indicates whether or not the exchange successfully completed |
 
-> **Note**
-> Include a section that explains rules around when a Close can/can't be sent.
+A `Close` can be sent by Alice _or_ the PFI at any point during the exchange, but a `Close` sent by Alice *after* an `Order` but does not guarantee the cancellation of an actively executing order. 
 
 #### Example Close
 ```json


### PR DESCRIPTION
Closes #257

Reference https://github.com/TBD54566975/tbdex/issues/242#issuecomment-1977002689

1. Close messages are valid after any message type
2. Close message introduces a new optional property `success` of type boolean

---

# Implementors

@jiyoontbd @kirahsapong @diehuxx (please tag anyone else in the comment section if appropriate)

Two things.

First, `Close` is now valid after any message type. I believe in some implementations we have a function akin to `isValidNext()` which inspects the message type (& its contents?) and determines if the given message is valid as the next message in the exchange. In places where we do have this code, we'll need to ensure it allows `Close` messages at any point.

Second, add a new property `Close.success` which is an _optional_ boolean. Ensure that `success` is accessible during creation/validation/parsing/etc (wherever appropriate).
