### PR TITLE
revert external refs to types

### DIFF
--- a/hosted/json-schemas/offering.schema.json
+++ b/hosted/json-schemas/offering.schema.json
@@ -47,7 +47,7 @@
                 "description": "Value that can be used to group specific payment methods together (e.g. Mobile Money vs. Direct Bank Deposit)."
               },
               "requiredPaymentDetails": {
-                "$ref": "http://json-schema.org/draft-07/schema",
+                "type": "object",
                 "description": "A JSON Schema containing the fields that need to be collected in order to use this payment method"
               },
               "min": {
@@ -108,7 +108,7 @@
                 "description": "Value that can be used to group specific payment methods together (e.g. Mobile Money vs. Direct Bank Deposit)."
               },
               "requiredPaymentDetails": {
-                "$ref": "http://json-schema.org/draft-07/schema",
+                "type": "object",
                 "description": "A JSON Schema containing the fields that need to be collected in order to use this payment method"
               },
               "min": {


### PR DESCRIPTION
external $refs introduces ajv generating a `require` in our ts validator. these $refs are valid to use but due to ajv injecting require syntax with externally resolved urls, reverting to `type: object`