### PR TITLE
Align List Offerings query params with all SDKs

### DIFF
--- a/specs/http-api/README.md
+++ b/specs/http-api/README.md
@@ -272,7 +272,7 @@ False
 ### Query Params
 | Param              | Description                                                                                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `payinCurrency`     | The primary currency listed in a currency pair, representing the unit being traded. **This is the currency that Alice will be _receiving_**                        |
+| `payinCurrency`     | The payin unit of a given currency pair offered for exchange. **This is the currency that the PFI will be _receiving_**                        |
 | `payoutCurrency`    | The secondary currency listed in a currency pair, indicating its value in relation to the base currency. **This is the currency that the PFI will be _receiving_** |
 | `id`               | Query for a specific offering                                                                                                                                      |
 

--- a/specs/http-api/README.md
+++ b/specs/http-api/README.md
@@ -273,7 +273,7 @@ False
 | Param              | Description                                                                                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `payinCurrency`     | The payin unit of a given currency pair offered for exchange. **This is the currency that the PFI will be _receiving_**                        |
-| `payoutCurrency`    | The secondary currency listed in a currency pair, indicating its value in relation to the base currency. **This is the currency that the PFI will be _receiving_** |
+| `payoutCurrency`    | The payout unit of a given currency pair offered for exchange. **This is the currency that Alice will be _receiving_** |
 | `id`               | Query for a specific offering                                                                                                                                      |
 
 

--- a/specs/http-api/README.md
+++ b/specs/http-api/README.md
@@ -272,10 +272,8 @@ False
 ### Query Params
 | Param              | Description                                                                                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `baseCurrency`     | The primary currency listed in a currency pair, representing the unit being traded. **This is the currency that Alice will be _receiving_**                        |
-| `quoteCurrency`    | The secondary currency listed in a currency pair, indicating its value in relation to the base currency. **This is the currency that the PFI will be _receiving_** |
-| `payinMethodKind`  | The payin method Alice wishes to use to provide quote currency                                                                                                     |
-| `payoutMethodKind` | The payout method Alice wishes to use to receive base currency                                                                                                     |
+| `payinCurrency`     | The primary currency listed in a currency pair, representing the unit being traded. **This is the currency that Alice will be _receiving_**                        |
+| `payoutCurrency`    | The secondary currency listed in a currency pair, indicating its value in relation to the base currency. **This is the currency that the PFI will be _receiving_** |
 | `id`               | Query for a specific offering                                                                                                                                      |
 
 


### PR DESCRIPTION
thanks @kirahsapong for flagging

It seems that our SDKs match each other, but not the spec. IMO The SDKs have the better idea for naming. So let's update the spec to match.