### PR TITLE
#274 Create salted hashes of privateData in Rfq

### DIFF
--- a/hosted/json-schemas/message.schema.json
+++ b/hosted/json-schemas/message.schema.json
@@ -41,10 +41,6 @@
         }
       },
       "required": ["from", "to", "kind", "id", "exchangeId", "createdAt", "protocol"]
-    },
-    "Private": {
-      "type": "object",
-      "description": "An ephemeral JSON object used to transmit sensitive data (e.g. PII)"
     }
   },
   "type": "object",
@@ -60,8 +56,9 @@
       "type": "string",
       "description": "Signature that verifies the authenticity and integrity of a message"
     },
-    "private": {
-      "$ref": "#/definitions/Private"
+    "privateData": {
+      "type": "object",
+      "description": "Private data which can be detached from the payload without disrupting integrity. Only used in RFQs"
     }
   },
   "additionalProperties": false,

--- a/hosted/json-schemas/rfq-private.schema.json
+++ b/hosted/json-schemas/rfq-private.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.dev/rfq-private.schema.json",
+  "type": "object",
+  "properties": {
+    "additionalProperties": false,
+    "salt": {
+      "type": "string",
+      "description": "Randomly generated cryptographic salt used to hash privateData fields"
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Presentation Submission that fulfills the requirements included in the respective Offering"
+    },
+    "payin": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "paymentDetails": {
+          "type": "object",
+          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        }
+      }
+    },
+    "payout": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "paymentDetails": {
+          "type": "object",
+          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        }
+      }
+    }
+  }
+}

--- a/hosted/json-schemas/rfq.schema.json
+++ b/hosted/json-schemas/rfq.schema.json
@@ -8,12 +8,12 @@
       "type": "string",
       "description": "Offering which Alice would like to get a quote for"
     },
-    "claims": {
+    "claimsHashes": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "Presentation Submission that fulfills the requirements included in the respective Offering"
+      "description": "Digests of Presentation Submissions that fulfills the requirements included in the respective Offering"
     },
     "payin": {
       "type": "object",
@@ -25,9 +25,9 @@
           "type": "string",
           "description": "Type of payment method e.g. BTC_ADDRESS, DEBIT_CARD, MOMO_MPESA"
         },
-        "paymentDetails": {
-          "type": "object",
-          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        "paymentDetailsHash": {
+          "type": "string",
+          "description": "Digest of an object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
         }
       },
       "required": ["amount", "kind"]
@@ -39,13 +39,13 @@
           "type": "string",
           "description": "Selected payout method from the respective offering"
         },
-        "paymentDetails": {
-          "type": "object",
-          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        "paymentDetailsHash": {
+          "type": "string",
+          "description": "Digest of an object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
         }
       },
       "required": ["kind"]
     }
   },
-  "required": ["offeringId", "claims", "payin", "payout"]
+  "required": ["offeringId", "claimsHashes", "payin", "payout"]
 }

--- a/hosted/json-schemas/rfq.schema.json
+++ b/hosted/json-schemas/rfq.schema.json
@@ -8,11 +8,8 @@
       "type": "string",
       "description": "Offering which Alice would like to get a quote for"
     },
-    "claimsHashes": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
+    "claimsHash": {
+      "type": "string",
       "description": "Digests of Presentation Submissions that fulfills the requirements included in the respective Offering"
     },
     "payin": {
@@ -47,5 +44,5 @@
       "required": ["kind"]
     }
   },
-  "required": ["offeringId", "claimsHashes", "payin", "payout"]
+  "required": ["offeringId", "payin", "payout"]
 }

--- a/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
+++ b/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
@@ -1,32 +1,30 @@
 {
   "description": "RFQ with privateData omitted parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:iz9zh671dx4jqwoyq97uz8qqf5hyqs5ytrrxa9m1xwap666i3kto\",\"to\":\"did:dht:fdromy6ze46cjzwfq1pr5t6n8183zf8oag7scsmmj8w5c1xx8z4o\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht17a15deb881rrntknz32ac\",\"exchangeId\":\"rfq_01ht17a15deb881rrntknz32ac\",\"createdAt\":\"2024-03-28T00:28:10.797Z\"},\"data\":{\"offeringId\":\"offering_01ht17a15cfmpbr4w1je3c0jwy\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"4H-bZ9ebWsd0Gvpnyr0_kynmyLk4ZMYx1OyvA3DD8b8\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aXo5emg2NzFkeDRqcXdveXE5N3V6OHFxZjVoeXFzNXl0cnJ4YTltMXh3YXA2NjZpM2t0byMwIn0..wkllHLmSCJWT9Vo3F2yAY-UhvST1nirK4qS9ycGN0kpE-N7IahlgkqCQDd6kiHAIElJxWVTHI5PSZ3tS-SVEAw\"}",
+  "input": "{\"metadata\":{\"from\":\"did:dht:9kkuh34q7nkd4tphbcg7py9h1g16iftbtskesi9courdwj96q3sy\",\"to\":\"did:dht:8rqqxczxhdugndj5mykiahy7y4zg4zkk3jajr6qyo5owdrgqqx3y\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht6fh3fwe8etr9v0fkp0ffye\",\"exchangeId\":\"rfq_01ht6fh3fwe8etr9v0fkp0ffye\",\"createdAt\":\"2024-03-30T01:28:03.324Z\"},\"data\":{\"offeringId\":\"offering_01ht6fh3fwe8etr9v0fdrm75w7\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"L7tSdDuyGRNzsLta-9u2rxhz9-hY7iWVGomgnMcZWjQ\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"IR8FJQ8N68UPY5lrmylik4vbNFLodXn6R2w2eEdoxNc\"},\"claimsHash\":\"ccCbBV6ONcYloiS_NKo2aFnJlibuG5cK-zy74YmBQW0\"},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0..HApQWjaJ_jpqfkCixd3FzZOqFjSVtuFbRkipp-jZ-ZnMW5TED-o2WFnu2dkWCVt-Zv7xQWmSkFqeIy6O0PZsBA\"}",
   "output": {
     "metadata": {
-      "from": "did:dht:iz9zh671dx4jqwoyq97uz8qqf5hyqs5ytrrxa9m1xwap666i3kto",
-      "to": "did:dht:fdromy6ze46cjzwfq1pr5t6n8183zf8oag7scsmmj8w5c1xx8z4o",
+      "from": "did:dht:9kkuh34q7nkd4tphbcg7py9h1g16iftbtskesi9courdwj96q3sy",
+      "to": "did:dht:8rqqxczxhdugndj5mykiahy7y4zg4zkk3jajr6qyo5owdrgqqx3y",
       "protocol": "1.0",
       "kind": "rfq",
-      "id": "rfq_01ht17a15deb881rrntknz32ac",
-      "exchangeId": "rfq_01ht17a15deb881rrntknz32ac",
-      "createdAt": "2024-03-28T00:28:10.797Z"
+      "id": "rfq_01ht6fh3fwe8etr9v0fkp0ffye",
+      "exchangeId": "rfq_01ht6fh3fwe8etr9v0fkp0ffye",
+      "createdAt": "2024-03-30T01:28:03.324Z"
     },
     "data": {
-      "offeringId": "offering_01ht17a15cfmpbr4w1je3c0jwy",
+      "offeringId": "offering_01ht6fh3fwe8etr9v0fdrm75w7",
       "payin": {
         "kind": "DEBIT_CARD",
         "amount": "20000.00",
-        "paymentDetailsHash": "YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4"
+        "paymentDetailsHash": "L7tSdDuyGRNzsLta-9u2rxhz9-hY7iWVGomgnMcZWjQ"
       },
       "payout": {
         "kind": "BTC_ADDRESS",
-        "paymentDetailsHash": "wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI"
+        "paymentDetailsHash": "IR8FJQ8N68UPY5lrmylik4vbNFLodXn6R2w2eEdoxNc"
       },
-      "claimsHashes": [
-        "4H-bZ9ebWsd0Gvpnyr0_kynmyLk4ZMYx1OyvA3DD8b8"
-      ]
+      "claimsHash": "ccCbBV6ONcYloiS_NKo2aFnJlibuG5cK-zy74YmBQW0"
     },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aXo5emg2NzFkeDRqcXdveXE5N3V6OHFxZjVoeXFzNXl0cnJ4YTltMXh3YXA2NjZpM2t0byMwIn0..wkllHLmSCJWT9Vo3F2yAY-UhvST1nirK4qS9ycGN0kpE-N7IahlgkqCQDd6kiHAIElJxWVTHI5PSZ3tS-SVEAw"
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0..HApQWjaJ_jpqfkCixd3FzZOqFjSVtuFbRkipp-jZ-ZnMW5TED-o2WFnu2dkWCVt-Zv7xQWmSkFqeIy6O0PZsBA"
   },
   "error": false
 }

--- a/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
+++ b/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
@@ -1,18 +1,18 @@
 {
-  "description": "RFQ parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:9trnwwi65s8m1mt3c83q4xfx4cnpeh5x1d7fskfrt15sfmgqjx5y\",\"to\":\"did:dht:ob18b7hgz85hkwg4djxo7hrkpgdasn37sqtpc55hi5dxrpupwedy\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht15qkvzfnxrgkckec2bje0n\",\"exchangeId\":\"rfq_01ht15qkvzfnxrgkckec2bje0n\",\"createdAt\":\"2024-03-28T00:00:38.783Z\"},\"data\":{\"offeringId\":\"offering_01ht15qkvzfnxrgkckebwzgakt\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"4_8AOG_lI2zUMO70BUuvqgPqYtBy_LcI0QBMdR4t0U8\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0..oGNj-i8C3RHU9wZSer728FFTonBsm_IYYeSBAjtUX71vLbNxLkFxeUvKjKdVYJYtRHQbOFHJ7fjDYTYQ4CVQCw\",\"privateData\":{\"salt\":\"123\",\"payin\":{\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payout\":{\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmIwZjAwNjVlLWNkMDAtNGYwYi1hZWJiLTNkMGRmMzM3ODU0NCIsImlzc3VlciI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjhUMDA6MDA6MzhaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojl0cm53d2k2NXM4bTFtdDNjODNxNHhmeDRjbnBlaDV4MWQ3ZnNrZnJ0MTVzZm1ncWp4NXkiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5Iiwic3ViIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5In0.6uO0Pl9JFx2ypuJf4BR-bgi5iLFdDdmvTETIi4fOYvVZ8P0kgoHaGvyrHiEsTadHgDMWFswArL_ds6B3G664Bw\"]}}",
+  "description": "RFQ with privateData omitted parses from string",
+  "input": "{\"metadata\":{\"from\":\"did:dht:iz9zh671dx4jqwoyq97uz8qqf5hyqs5ytrrxa9m1xwap666i3kto\",\"to\":\"did:dht:fdromy6ze46cjzwfq1pr5t6n8183zf8oag7scsmmj8w5c1xx8z4o\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht17a15deb881rrntknz32ac\",\"exchangeId\":\"rfq_01ht17a15deb881rrntknz32ac\",\"createdAt\":\"2024-03-28T00:28:10.797Z\"},\"data\":{\"offeringId\":\"offering_01ht17a15cfmpbr4w1je3c0jwy\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"4H-bZ9ebWsd0Gvpnyr0_kynmyLk4ZMYx1OyvA3DD8b8\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aXo5emg2NzFkeDRqcXdveXE5N3V6OHFxZjVoeXFzNXl0cnJ4YTltMXh3YXA2NjZpM2t0byMwIn0..wkllHLmSCJWT9Vo3F2yAY-UhvST1nirK4qS9ycGN0kpE-N7IahlgkqCQDd6kiHAIElJxWVTHI5PSZ3tS-SVEAw\"}",
   "output": {
     "metadata": {
-      "from": "did:dht:9trnwwi65s8m1mt3c83q4xfx4cnpeh5x1d7fskfrt15sfmgqjx5y",
-      "to": "did:dht:ob18b7hgz85hkwg4djxo7hrkpgdasn37sqtpc55hi5dxrpupwedy",
+      "from": "did:dht:iz9zh671dx4jqwoyq97uz8qqf5hyqs5ytrrxa9m1xwap666i3kto",
+      "to": "did:dht:fdromy6ze46cjzwfq1pr5t6n8183zf8oag7scsmmj8w5c1xx8z4o",
       "protocol": "1.0",
       "kind": "rfq",
-      "id": "rfq_01ht15qkvzfnxrgkckec2bje0n",
-      "exchangeId": "rfq_01ht15qkvzfnxrgkckec2bje0n",
-      "createdAt": "2024-03-28T00:00:38.783Z"
+      "id": "rfq_01ht17a15deb881rrntknz32ac",
+      "exchangeId": "rfq_01ht17a15deb881rrntknz32ac",
+      "createdAt": "2024-03-28T00:28:10.797Z"
     },
     "data": {
-      "offeringId": "offering_01ht15qkvzfnxrgkckebwzgakt",
+      "offeringId": "offering_01ht17a15cfmpbr4w1je3c0jwy",
       "payin": {
         "kind": "DEBIT_CARD",
         "amount": "20000.00",
@@ -23,29 +23,10 @@
         "paymentDetailsHash": "wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI"
       },
       "claimsHashes": [
-        "4_8AOG_lI2zUMO70BUuvqgPqYtBy_LcI0QBMdR4t0U8"
+        "4H-bZ9ebWsd0Gvpnyr0_kynmyLk4ZMYx1OyvA3DD8b8"
       ]
     },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0..oGNj-i8C3RHU9wZSer728FFTonBsm_IYYeSBAjtUX71vLbNxLkFxeUvKjKdVYJYtRHQbOFHJ7fjDYTYQ4CVQCw",
-    "privateData": {
-      "salt": "123",
-      "payin": {
-        "paymentDetails": {
-          "cardNumber": "1234567890123456",
-          "expiryDate": "12/22",
-          "cardHolderName": "Ephraim Bartholomew Winthrop",
-          "cvv": "123"
-        }
-      },
-      "payout": {
-        "paymentDetails": {
-          "btcAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
-        }
-      },
-      "claims": [
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmIwZjAwNjVlLWNkMDAtNGYwYi1hZWJiLTNkMGRmMzM3ODU0NCIsImlzc3VlciI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjhUMDA6MDA6MzhaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojl0cm53d2k2NXM4bTFtdDNjODNxNHhmeDRjbnBlaDV4MWQ3ZnNrZnJ0MTVzZm1ncWp4NXkiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5Iiwic3ViIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5In0.6uO0Pl9JFx2ypuJf4BR-bgi5iLFdDdmvTETIi4fOYvVZ8P0kgoHaGvyrHiEsTadHgDMWFswArL_ds6B3G664Bw"
-      ]
-    }
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aXo5emg2NzFkeDRqcXdveXE5N3V6OHFxZjVoeXFzNXl0cnJ4YTltMXh3YXA2NjZpM2t0byMwIn0..wkllHLmSCJWT9Vo3F2yAY-UhvST1nirK4qS9ycGN0kpE-N7IahlgkqCQDd6kiHAIElJxWVTHI5PSZ3tS-SVEAw"
   },
   "error": false
 }

--- a/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
+++ b/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json
@@ -1,0 +1,51 @@
+{
+  "description": "RFQ parses from string",
+  "input": "{\"metadata\":{\"from\":\"did:dht:9trnwwi65s8m1mt3c83q4xfx4cnpeh5x1d7fskfrt15sfmgqjx5y\",\"to\":\"did:dht:ob18b7hgz85hkwg4djxo7hrkpgdasn37sqtpc55hi5dxrpupwedy\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht15qkvzfnxrgkckec2bje0n\",\"exchangeId\":\"rfq_01ht15qkvzfnxrgkckec2bje0n\",\"createdAt\":\"2024-03-28T00:00:38.783Z\"},\"data\":{\"offeringId\":\"offering_01ht15qkvzfnxrgkckebwzgakt\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"4_8AOG_lI2zUMO70BUuvqgPqYtBy_LcI0QBMdR4t0U8\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0..oGNj-i8C3RHU9wZSer728FFTonBsm_IYYeSBAjtUX71vLbNxLkFxeUvKjKdVYJYtRHQbOFHJ7fjDYTYQ4CVQCw\",\"privateData\":{\"salt\":\"123\",\"payin\":{\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payout\":{\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmIwZjAwNjVlLWNkMDAtNGYwYi1hZWJiLTNkMGRmMzM3ODU0NCIsImlzc3VlciI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjhUMDA6MDA6MzhaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojl0cm53d2k2NXM4bTFtdDNjODNxNHhmeDRjbnBlaDV4MWQ3ZnNrZnJ0MTVzZm1ncWp4NXkiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5Iiwic3ViIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5In0.6uO0Pl9JFx2ypuJf4BR-bgi5iLFdDdmvTETIi4fOYvVZ8P0kgoHaGvyrHiEsTadHgDMWFswArL_ds6B3G664Bw\"]}}",
+  "output": {
+    "metadata": {
+      "from": "did:dht:9trnwwi65s8m1mt3c83q4xfx4cnpeh5x1d7fskfrt15sfmgqjx5y",
+      "to": "did:dht:ob18b7hgz85hkwg4djxo7hrkpgdasn37sqtpc55hi5dxrpupwedy",
+      "protocol": "1.0",
+      "kind": "rfq",
+      "id": "rfq_01ht15qkvzfnxrgkckec2bje0n",
+      "exchangeId": "rfq_01ht15qkvzfnxrgkckec2bje0n",
+      "createdAt": "2024-03-28T00:00:38.783Z"
+    },
+    "data": {
+      "offeringId": "offering_01ht15qkvzfnxrgkckebwzgakt",
+      "payin": {
+        "kind": "DEBIT_CARD",
+        "amount": "20000.00",
+        "paymentDetailsHash": "YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4"
+      },
+      "payout": {
+        "kind": "BTC_ADDRESS",
+        "paymentDetailsHash": "wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI"
+      },
+      "claimsHashes": [
+        "4_8AOG_lI2zUMO70BUuvqgPqYtBy_LcI0QBMdR4t0U8"
+      ]
+    },
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0..oGNj-i8C3RHU9wZSer728FFTonBsm_IYYeSBAjtUX71vLbNxLkFxeUvKjKdVYJYtRHQbOFHJ7fjDYTYQ4CVQCw",
+    "privateData": {
+      "salt": "123",
+      "payin": {
+        "paymentDetails": {
+          "cardNumber": "1234567890123456",
+          "expiryDate": "12/22",
+          "cardHolderName": "Ephraim Bartholomew Winthrop",
+          "cvv": "123"
+        }
+      },
+      "payout": {
+        "paymentDetails": {
+          "btcAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+        }
+      },
+      "claims": [
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmIwZjAwNjVlLWNkMDAtNGYwYi1hZWJiLTNkMGRmMzM3ODU0NCIsImlzc3VlciI6ImRpZDpkaHQ6OXRybnd3aTY1czhtMW10M2M4M3E0eGZ4NGNucGVoNXgxZDdmc2tmcnQxNXNmbWdxang1eSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjhUMDA6MDA6MzhaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojl0cm53d2k2NXM4bTFtdDNjODNxNHhmeDRjbnBlaDV4MWQ3ZnNrZnJ0MTVzZm1ncWp4NXkiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5Iiwic3ViIjoiZGlkOmRodDo5dHJud3dpNjVzOG0xbXQzYzgzcTR4Zng0Y25wZWg1eDFkN2Zza2ZydDE1c2ZtZ3FqeDV5In0.6uO0Pl9JFx2ypuJf4BR-bgi5iLFdDdmvTETIi4fOYvVZ8P0kgoHaGvyrHiEsTadHgDMWFswArL_ds6B3G664Bw"
+      ]
+    }
+  },
+  "error": false
+}

--- a/hosted/test-vectors/protocol/vectors/parse-rfq.json
+++ b/hosted/test-vectors/protocol/vectors/parse-rfq.json
@@ -1,34 +1,32 @@
 {
   "description": "RFQ parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:hybk1aqkk1gyf3xf65n4i5i8eejuf1i8z815rdu151iyyas5kgqo\",\"to\":\"did:dht:zg49uprcdsnhcis5upqzz691pni3o7oisnih3eosxhxgngemj73y\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht15gcytfmmvmrsecezv1wtj\",\"exchangeId\":\"rfq_01ht15gcytfmmvmrsecezv1wtj\",\"createdAt\":\"2024-03-27T23:56:42.330Z\"},\"data\":{\"offeringId\":\"offering_01ht15gcytfmmvmrsec8sycmxv\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"iaJKmdBSPJ3rz9U1laNbZDgvNNZER3TTy8DqRqSCbdc\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0..BvGDK2E4azbc_TtOIN48ZEMig0hUghPswBgUiZ7zbKnCELZZffiLbLueS7qDuiZmjz6_iXhFO5oHSnZeqhtYAg\",\"privateData\":{\"salt\":\"123\",\"payin\":{\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payout\":{\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOjlkM2M1OGQ1LTI5NzMtNDI4Zi04YjNkLWY4ZGI1MmIzNGI1MyIsImlzc3VlciI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjdUMjM6NTY6NDJaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Omh5YmsxYXFrazFneWYzeGY2NW40aTVpOGVlanVmMWk4ejgxNXJkdTE1MWl5eWFzNWtncW8iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIiwic3ViIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIn0.gQMcjzeKdhcDExx1mtrLnA9g_MahmTuJWumgFOSY9TtY1bEDB77ZykaeuYvc0hotJuEmQSng3uecH-lsMuk0BA\"]}}",
+  "input": "{\"metadata\":{\"from\":\"did:dht:9kkuh34q7nkd4tphbcg7py9h1g16iftbtskesi9courdwj96q3sy\",\"to\":\"did:dht:8rqqxczxhdugndj5mykiahy7y4zg4zkk3jajr6qyo5owdrgqqx3y\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht6fh3fsf9z8ekh5tyjbsmwk\",\"exchangeId\":\"rfq_01ht6fh3fsf9z8ekh5tyjbsmwk\",\"createdAt\":\"2024-03-30T01:28:03.321Z\"},\"data\":{\"offeringId\":\"offering_01ht6fh3fre7t8zfc6j97t2pe1\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"k8nU7MKYNb140u3pN8FO5ndAK3WDJ8lQDEsYA0H9fWA\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"xwyJqXOcLsYBBojNlVHZGZzlhZvswFPUh3xsLxus_EU\"},\"claimsHash\":\"o16anc251kJb3uyYKzPdlS5SdhGomylHZ8_YZ7CBbgU\"},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0..R-dVpTPg0m4mejuadBwlSACXNqYvCm4qajhD1K8mX2r85ukz2INrEjp1OA4Yp4vr2gg57JzREb_KLnTOurChAA\",\"privateData\":{\"salt\":\"�>�����\\u0014�]�NɈ\",\"payin\":{\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payout\":{\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmY5YWVlNjdjLTQ1NmUtNGU1Yy05NDg3LWM3MjM2ZmQyMWUxNiIsImlzc3VlciI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMzBUMDE6Mjg6MDNaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojlra3VoMzRxN25rZDR0cGhiY2c3cHk5aDFnMTZpZnRidHNrZXNpOWNvdXJkd2o5NnEzc3kiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5a2t1aDM0cTdua2Q0dHBoYmNnN3B5OWgxZzE2aWZ0YnRza2VzaTljb3VyZHdqOTZxM3N5Iiwic3ViIjoiZGlkOmRodDo5a2t1aDM0cTdua2Q0dHBoYmNnN3B5OWgxZzE2aWZ0YnRza2VzaTljb3VyZHdqOTZxM3N5In0.kxFwk-eCpCrO1m7lYAlqEioGjVZ1vlM-DctE52atVKa6Egn-DS0nqmqDcXo_yRmAUylU5E-7lOPsP7N90DbAAA\"]}}",
   "output": {
     "metadata": {
-      "from": "did:dht:hybk1aqkk1gyf3xf65n4i5i8eejuf1i8z815rdu151iyyas5kgqo",
-      "to": "did:dht:zg49uprcdsnhcis5upqzz691pni3o7oisnih3eosxhxgngemj73y",
+      "from": "did:dht:9kkuh34q7nkd4tphbcg7py9h1g16iftbtskesi9courdwj96q3sy",
+      "to": "did:dht:8rqqxczxhdugndj5mykiahy7y4zg4zkk3jajr6qyo5owdrgqqx3y",
       "protocol": "1.0",
       "kind": "rfq",
-      "id": "rfq_01ht15gcytfmmvmrsecezv1wtj",
-      "exchangeId": "rfq_01ht15gcytfmmvmrsecezv1wtj",
-      "createdAt": "2024-03-27T23:56:42.330Z"
+      "id": "rfq_01ht6fh3fsf9z8ekh5tyjbsmwk",
+      "exchangeId": "rfq_01ht6fh3fsf9z8ekh5tyjbsmwk",
+      "createdAt": "2024-03-30T01:28:03.321Z"
     },
     "data": {
-      "offeringId": "offering_01ht15gcytfmmvmrsec8sycmxv",
+      "offeringId": "offering_01ht6fh3fre7t8zfc6j97t2pe1",
       "payin": {
         "kind": "DEBIT_CARD",
         "amount": "20000.00",
-        "paymentDetailsHash": "YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4"
+        "paymentDetailsHash": "k8nU7MKYNb140u3pN8FO5ndAK3WDJ8lQDEsYA0H9fWA"
       },
       "payout": {
         "kind": "BTC_ADDRESS",
-        "paymentDetailsHash": "wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI"
+        "paymentDetailsHash": "xwyJqXOcLsYBBojNlVHZGZzlhZvswFPUh3xsLxus_EU"
       },
-      "claimsHashes": [
-        "iaJKmdBSPJ3rz9U1laNbZDgvNNZER3TTy8DqRqSCbdc"
-      ]
+      "claimsHash": "o16anc251kJb3uyYKzPdlS5SdhGomylHZ8_YZ7CBbgU"
     },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0..BvGDK2E4azbc_TtOIN48ZEMig0hUghPswBgUiZ7zbKnCELZZffiLbLueS7qDuiZmjz6_iXhFO5oHSnZeqhtYAg",
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0..R-dVpTPg0m4mejuadBwlSACXNqYvCm4qajhD1K8mX2r85ukz2INrEjp1OA4Yp4vr2gg57JzREb_KLnTOurChAA",
     "privateData": {
-      "salt": "123",
+      "salt": "�>�����\u0014�]�NɈ",
       "payin": {
         "paymentDetails": {
           "cardNumber": "1234567890123456",
@@ -43,7 +41,7 @@
         }
       },
       "claims": [
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOjlkM2M1OGQ1LTI5NzMtNDI4Zi04YjNkLWY4ZGI1MmIzNGI1MyIsImlzc3VlciI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjdUMjM6NTY6NDJaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Omh5YmsxYXFrazFneWYzeGY2NW40aTVpOGVlanVmMWk4ejgxNXJkdTE1MWl5eWFzNWtncW8iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIiwic3ViIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIn0.gQMcjzeKdhcDExx1mtrLnA9g_MahmTuJWumgFOSY9TtY1bEDB77ZykaeuYvc0hotJuEmQSng3uecH-lsMuk0BA"
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmY5YWVlNjdjLTQ1NmUtNGU1Yy05NDg3LWM3MjM2ZmQyMWUxNiIsImlzc3VlciI6ImRpZDpkaHQ6OWtrdWgzNHE3bmtkNHRwaGJjZzdweTloMWcxNmlmdGJ0c2tlc2k5Y291cmR3ajk2cTNzeSIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMzBUMDE6Mjg6MDNaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Ojlra3VoMzRxN25rZDR0cGhiY2c3cHk5aDFnMTZpZnRidHNrZXNpOWNvdXJkd2o5NnEzc3kiLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDo5a2t1aDM0cTdua2Q0dHBoYmNnN3B5OWgxZzE2aWZ0YnRza2VzaTljb3VyZHdqOTZxM3N5Iiwic3ViIjoiZGlkOmRodDo5a2t1aDM0cTdua2Q0dHBoYmNnN3B5OWgxZzE2aWZ0YnRza2VzaTljb3VyZHdqOTZxM3N5In0.kxFwk-eCpCrO1m7lYAlqEioGjVZ1vlM-DctE52atVKa6Egn-DS0nqmqDcXo_yRmAUylU5E-7lOPsP7N90DbAAA"
       ]
     }
   },

--- a/hosted/test-vectors/protocol/vectors/parse-rfq.json
+++ b/hosted/test-vectors/protocol/vectors/parse-rfq.json
@@ -1,20 +1,35 @@
 {
   "description": "RFQ parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:3bexemzgf5bw7oj47uspgd47gj64kr7j7gta4wsjgeu6qtiq1s7o\",\"to\":\"did:dht:otd1sndnrp9kprin9xcyj4pquyqunef465nm98pdniaug3e6mc5o\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01hsd3rqqeeb4t9539vjprtfz8\",\"exchangeId\":\"rfq_01hsd3rqqeeb4t9539vjprtfz8\",\"createdAt\":\"2024-03-20T05:01:29.710Z\"},\"data\":{\"offeringId\":\"offering_01hsd3rqqeeb4t9539vf68mcf8\",\"payinMethod\":{\"kind\":\"DEBIT_CARD\",\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payoutMethod\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"payinAmount\":\"20000.00\",\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmU3MTgzN2NlLTFkODMtNDZjOS04ODMxLWYyOTNmZWFjOTBiMiIsImlzc3VlciI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjBUMDU6MDE6MjlaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0OjNiZXhlbXpnZjVidzdvajQ3dXNwZ2Q0N2dqNjRrcjdqN2d0YTR3c2pnZXU2cXRpcTFzN28iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDozYmV4ZW16Z2Y1Ync3b2o0N3VzcGdkNDdnajY0a3I3ajdndGE0d3NqZ2V1NnF0aXExczdvIiwic3ViIjoiZGlkOmRodDozYmV4ZW16Z2Y1Ync3b2o0N3VzcGdkNDdnajY0a3I3ajdndGE0d3NqZ2V1NnF0aXExczdvIn0.9vFvgKajc3CBMOiZln3Sac39cbAaRghMH5da4oKm4-xTctryVHSvsqJmyGgyLC7eQ4rOZcAZsy6Mts325eRBCw\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byMwIn0..pSvEzCyIrvFjeT95_IiUgqPLx6gdZAL0wfAeLoPbWQkiyYlVNsCnD7EisZtGVCkYCd4CIgodUdsnpAC4TRikDw\"}",
+  "input": "{\"metadata\":{\"from\":\"did:dht:hybk1aqkk1gyf3xf65n4i5i8eejuf1i8z815rdu151iyyas5kgqo\",\"to\":\"did:dht:zg49uprcdsnhcis5upqzz691pni3o7oisnih3eosxhxgngemj73y\",\"protocol\":\"1.0\",\"kind\":\"rfq\",\"id\":\"rfq_01ht15gcytfmmvmrsecezv1wtj\",\"exchangeId\":\"rfq_01ht15gcytfmmvmrsecezv1wtj\",\"createdAt\":\"2024-03-27T23:56:42.330Z\"},\"data\":{\"offeringId\":\"offering_01ht15gcytfmmvmrsec8sycmxv\",\"payin\":{\"kind\":\"DEBIT_CARD\",\"amount\":\"20000.00\",\"paymentDetailsHash\":\"YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4\"},\"payout\":{\"kind\":\"BTC_ADDRESS\",\"paymentDetailsHash\":\"wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI\"},\"claimsHashes\":[\"iaJKmdBSPJ3rz9U1laNbZDgvNNZER3TTy8DqRqSCbdc\"]},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0..BvGDK2E4azbc_TtOIN48ZEMig0hUghPswBgUiZ7zbKnCELZZffiLbLueS7qDuiZmjz6_iXhFO5oHSnZeqhtYAg\",\"privateData\":{\"salt\":\"123\",\"payin\":{\"paymentDetails\":{\"cardNumber\":\"1234567890123456\",\"expiryDate\":\"12/22\",\"cardHolderName\":\"Ephraim Bartholomew Winthrop\",\"cvv\":\"123\"}},\"payout\":{\"paymentDetails\":{\"btcAddress\":\"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa\"}},\"claims\":[\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOjlkM2M1OGQ1LTI5NzMtNDI4Zi04YjNkLWY4ZGI1MmIzNGI1MyIsImlzc3VlciI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjdUMjM6NTY6NDJaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Omh5YmsxYXFrazFneWYzeGY2NW40aTVpOGVlanVmMWk4ejgxNXJkdTE1MWl5eWFzNWtncW8iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIiwic3ViIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIn0.gQMcjzeKdhcDExx1mtrLnA9g_MahmTuJWumgFOSY9TtY1bEDB77ZykaeuYvc0hotJuEmQSng3uecH-lsMuk0BA\"]}}",
   "output": {
     "metadata": {
-      "from": "did:dht:3bexemzgf5bw7oj47uspgd47gj64kr7j7gta4wsjgeu6qtiq1s7o",
-      "to": "did:dht:otd1sndnrp9kprin9xcyj4pquyqunef465nm98pdniaug3e6mc5o",
+      "from": "did:dht:hybk1aqkk1gyf3xf65n4i5i8eejuf1i8z815rdu151iyyas5kgqo",
+      "to": "did:dht:zg49uprcdsnhcis5upqzz691pni3o7oisnih3eosxhxgngemj73y",
       "protocol": "1.0",
       "kind": "rfq",
-      "id": "rfq_01hsd3rqqeeb4t9539vjprtfz8",
-      "exchangeId": "rfq_01hsd3rqqeeb4t9539vjprtfz8",
-      "createdAt": "2024-03-20T05:01:29.710Z"
+      "id": "rfq_01ht15gcytfmmvmrsecezv1wtj",
+      "exchangeId": "rfq_01ht15gcytfmmvmrsecezv1wtj",
+      "createdAt": "2024-03-27T23:56:42.330Z"
     },
     "data": {
-      "offeringId": "offering_01hsd3rqqeeb4t9539vf68mcf8",
-      "payinMethod": {
+      "offeringId": "offering_01ht15gcytfmmvmrsec8sycmxv",
+      "payin": {
         "kind": "DEBIT_CARD",
+        "amount": "20000.00",
+        "paymentDetailsHash": "YhnSs26y0oj3YrzajVQWQoUTwOReENRZgXyVyCs_ON4"
+      },
+      "payout": {
+        "kind": "BTC_ADDRESS",
+        "paymentDetailsHash": "wtwAUlYVbMfGHVJ-F6VlAqpD4TwJpM8ep5Rv4JNNRCI"
+      },
+      "claimsHashes": [
+        "iaJKmdBSPJ3rz9U1laNbZDgvNNZER3TTy8DqRqSCbdc"
+      ]
+    },
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0..BvGDK2E4azbc_TtOIN48ZEMig0hUghPswBgUiZ7zbKnCELZZffiLbLueS7qDuiZmjz6_iXhFO5oHSnZeqhtYAg",
+    "privateData": {
+      "salt": "123",
+      "payin": {
         "paymentDetails": {
           "cardNumber": "1234567890123456",
           "expiryDate": "12/22",
@@ -22,18 +37,15 @@
           "cvv": "123"
         }
       },
-      "payoutMethod": {
-        "kind": "BTC_ADDRESS",
+      "payout": {
         "paymentDetails": {
           "btcAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
         }
       },
-      "payinAmount": "20000.00",
       "claims": [
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOmU3MTgzN2NlLTFkODMtNDZjOS04ODMxLWYyOTNmZWFjOTBiMiIsImlzc3VlciI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjBUMDU6MDE6MjlaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0OjNiZXhlbXpnZjVidzdvajQ3dXNwZ2Q0N2dqNjRrcjdqN2d0YTR3c2pnZXU2cXRpcTFzN28iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDozYmV4ZW16Z2Y1Ync3b2o0N3VzcGdkNDdnajY0a3I3ajdndGE0d3NqZ2V1NnF0aXExczdvIiwic3ViIjoiZGlkOmRodDozYmV4ZW16Z2Y1Ync3b2o0N3VzcGdkNDdnajY0a3I3ajdndGE0d3NqZ2V1NnF0aXExczdvIn0.9vFvgKajc3CBMOiZln3Sac39cbAaRghMH5da4oKm4-xTctryVHSvsqJmyGgyLC7eQ4rOZcAZsy6Mts325eRBCw"
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHV1cHV1Q3JlZGVudGlhbCJdLCJpZCI6InVybjp1dWlkOjlkM2M1OGQ1LTI5NzMtNDI4Zi04YjNkLWY4ZGI1MmIzNGI1MyIsImlzc3VlciI6ImRpZDpkaHQ6aHliazFhcWtrMWd5ZjN4ZjY1bjRpNWk4ZWVqdWYxaTh6ODE1cmR1MTUxaXl5YXM1a2dxbyIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjdUMjM6NTY6NDJaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZGh0Omh5YmsxYXFrazFneWYzeGY2NW40aTVpOGVlanVmMWk4ejgxNXJkdTE1MWl5eWFzNWtncW8iLCJiZWVwIjoiYm9vcCJ9fSwiaXNzIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIiwic3ViIjoiZGlkOmRodDpoeWJrMWFxa2sxZ3lmM3hmNjVuNGk1aThlZWp1ZjFpOHo4MTVyZHUxNTFpeXlhczVrZ3FvIn0.gQMcjzeKdhcDExx1mtrLnA9g_MahmTuJWumgFOSY9TtY1bEDB77ZykaeuYvc0hotJuEmQSng3uecH-lsMuk0BA"
       ]
-    },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M2JleGVtemdmNWJ3N29qNDd1c3BnZDQ3Z2o2NGtyN2o3Z3RhNHdzamdldTZxdGlxMXM3byMwIn0..pSvEzCyIrvFjeT95_IiUgqPLx6gdZAL0wfAeLoPbWQkiyYlVNsCnD7EisZtGVCkYCd4CIgodUdsnpAC4TRikDw"
+    }
   },
   "error": false
 }

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -341,7 +341,7 @@ The `metadata` object contains fields _about_ the message and is present in _eve
 
 
 | Field        | Required (Y/N) | Description                                                                                                                                                                                                                                                                                                    |
-|--------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `from`       | Y              | The sender's DID                                                                                                                                                                                                                                                                                               |
 | `to`         | Y              | the recipient's DID                                                                                                                                                                                                                                                                                            |
 | `kind`       | Y              | e.g. `rfq`, `quote` etc. This defines the `data` property's _type_                                                                                                                                                                                                                                             |
@@ -408,7 +408,7 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 > Alice -> PFI: "OK, that offering looks good. Give me a Quote against that Offering, and here is how much USD (payin currency) I want to trade for BTC (payout currency). Here are the credentials you're asking for, the payment method I intend to pay you USD with, and the payment method I expect you to pay me BTC in."
 
 | field        | data type                                        | required | description                                                 |
-|--------------|--------------------------------------------------|----------|-------------------------------------------------------------|
+| ------------ | ------------------------------------------------ | -------- | ----------------------------------------------------------- |
 | `offeringId` | string                                           | Y        | Offering which Alice would like to get a quote for          |
 | `claimsHash` | string[]                                         | Y        | Salted hash of the claims appearing in `privateDate.claims` |
 | `payin`      | [`SelectedPayinMethod`](#selectedpaymentmethod)  | Y        | selected payin amount, method, and details                  |
@@ -416,14 +416,14 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 
 #### `SelectedPayinMethod`
 | field                | data type                         | required | description                                                                 |
-|----------------------|-----------------------------------|----------|-----------------------------------------------------------------------------|
+| -------------------- | --------------------------------- | -------- | --------------------------------------------------------------------------- |
 | `amount`             | [`DecimalString`](#decimalstring) | Y        | Amount of payin currency you want in exchange for payout currency           |
 | `kind`               | string                            | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`) |
 | `paymentDetailsHash` | string                            | N        | A salted hash of `privateData.payin.paymentDetails`                         |
 
 #### `SelectedPayoutMethod`
 | field                | data type | required | description                                                                 |
-|----------------------|-----------|----------|-----------------------------------------------------------------------------|
+| -------------------- | --------- | -------- | --------------------------------------------------------------------------- |
 | `kind`               | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`) |
 | `paymentDetailsHash` | object    | N        | A salted hash of `privateData.payout.paymentDetails`                        |
 
@@ -434,11 +434,11 @@ In order to prevent storing this sensitive data with the message itself, an RFQ 
 
 Each property in `privateData` has a corresponding property in `data` with the suffix `Hash`. The salted hash of the property in `privateData` MUST match the value of the corresponding property in `data`. The following table enumerates all properties in `privateData` which have a corresponding property in `data`.
 
-| `privateData` property  | `data` property             | description                                                                                         |
-|-------------------------|-----------------------------|-----------------------------------------------------------------------------------------------------|--|
-| `payin.paymentDetails`  | `payin.paymentDetailsHash`  | The salted hash of `payin.paymentDetails` must match `payin.paymentDetailsHash`.                    |
-| `payout.paymentDetails` | `payout.paymentDetailsHash` | The salted hash of `payout.paymentDetails` must match `payout.paymentDetailsHash`.                  |
-| `claims`                | `claimsHash`                | The salted hash of `claims` MUST match `claimsHash`.                                                |
+| `privateData` property  | `data` property             | description                                                                        |
+| ----------------------- | --------------------------- | ---------------------------------------------------------------------------------- |
+| `payin.paymentDetails`  | `payin.paymentDetailsHash`  | The salted hash of `payin.paymentDetails` must match `payin.paymentDetailsHash`.   |
+| `payout.paymentDetails` | `payout.paymentDetailsHash` | The salted hash of `payout.paymentDetails` must match `payout.paymentDetailsHash`. |
+| `claims`                | `claimsHash`                | The salted hash of `claims` MUST match `claimsHash`.                               |
 
 The salted hash is produced by creating a [digest](#digests) of a JSON array containing a salt and the cleartext value that appears in `privateData`. For example, to produce `Rfq.data.payin.paymentDetailsHash`, create a digest of `[salt, Rfq.privateData.payin.paymentDetails]`. The RECOMMENDED minimum length of the randomly-generated portion of the salt is 128 bits. The salt is placed in `privateData.salt`. The salt MUST be present when `privateData` is present.
 
@@ -446,7 +446,7 @@ The `privateData` field is ephemeral and **MUST** only be present when the messa
 
 This table enumerates the structure of 
 | field    | data type                                         | required | description                                                                           |
-|----------|---------------------------------------------------|----------|---------------------------------------------------------------------------------------|
+| -------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
 | `salt`   | string                                            | N        |                                                                                       |
 | `claims` | string[]                                          | N        | an array of claims that fulfill the requirements declared in an [Offering](#offering) |
 | `payin`  | [`PrivatePaymentDetails`](#privatepaymentdetails) | N        | A container for the unhashed `payin.paymentDetails`                                   |

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -365,7 +365,7 @@ Message kinds other than RFQ may NOT have property `privateData`. The [RFQ `priv
 {
   "data": {
     "offeringId": <OFFERING_ID>,
-    "claimsHashes": [<VERIFIABLE_CREDENTIAL_HASH>], <---- hash
+    "claimsHash": <VERIFIABLE_CREDENTIAL_HASH>, <---- hash
     "payin": {
       "kind": "BTC_ADDRESS",
       "amount": "STR_VALUE",
@@ -407,12 +407,12 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 ### `RFQ (Request For Quote)`
 > Alice -> PFI: "OK, that offering looks good. Give me a Quote against that Offering, and here is how much USD (payin currency) I want to trade for BTC (payout currency). Here are the credentials you're asking for, the payment method I intend to pay you USD with, and the payment method I expect you to pay me BTC in."
 
-| field          | data type                                        | required | description                                                               |
-|----------------|--------------------------------------------------|----------|---------------------------------------------------------------------------|
-| `offeringId`   | string                                           | Y        | Offering which Alice would like to get a quote for                        |
-| `claimsHashes` | string[]                                         | Y        | an array of salted hashes of the claims appearing in `privateDate.claims` |
-| `payin`        | [`SelectedPayinMethod`](#selectedpaymentmethod)  | Y        | selected payin amount, method, and details                                |
-| `payout`       | [`SelectedPayoutMethod`](#selectedpaymentmethod) | Y        | selected payout method, and details                                       |
+| field        | data type                                        | required | description                                                 |
+|--------------|--------------------------------------------------|----------|-------------------------------------------------------------|
+| `offeringId` | string                                           | Y        | Offering which Alice would like to get a quote for          |
+| `claimsHash` | string[]                                         | Y        | Salted hash of the claims appearing in `privateDate.claims` |
+| `payin`      | [`SelectedPayinMethod`](#selectedpaymentmethod)  | Y        | selected payin amount, method, and details                  |
+| `payout`     | [`SelectedPayoutMethod`](#selectedpaymentmethod) | Y        | selected payout method, and details                         |
 
 #### `SelectedPayinMethod`
 | field                | data type                         | required | description                                                                 |
@@ -432,13 +432,13 @@ Often times, an RFQ will contain PII or PCI data either within the `claims` bein
 
 In order to prevent storing this sensitive data with the message itself, an RFQ may have property `privateData` which holds the raw values for certain fields, while the RFQ's `data` property holds salted hashes of the fields in `privateData`. `privateData` is NOT signed over, so the signature integrity of an RFQ can be verified even if `privateData` is not present.
 
-Each property in `privateData` has a corresponding property in `data` with the suffix `Hash` or `Hashes` if the value is an array. The salted hash of the property in `privateData` MUST match the value of the corresponding property in `data`. The following table enumerates all properties in `privateData` which have a corresponding property in `data`.
+Each property in `privateData` has a corresponding property in `data` with the suffix `Hash`. The salted hash of the property in `privateData` MUST match the value of the corresponding property in `data`. The following table enumerates all properties in `privateData` which have a corresponding property in `data`.
 
 | `privateData` property  | `data` property             | description                                                                                         |
 |-------------------------|-----------------------------|-----------------------------------------------------------------------------------------------------|--|
 | `payin.paymentDetails`  | `payin.paymentDetailsHash`  | The salted hash of `payin.paymentDetails` must match `payin.paymentDetailsHash`.                    |
 | `payout.paymentDetails` | `payout.paymentDetailsHash` | The salted hash of `payout.paymentDetails` must match `payout.paymentDetailsHash`.                  |
-| `claims`                | `claimsHashes`              | The salted hash of each element in `claims` MUST match the corresponding element in `claimsHashes`. |
+| `claims`                | `claimsHash`                | The salted hash of `claims` MUST match `claimsHash`.                                                |
 
 The salted hash is produced by creating a [digest](#digests) of a JSON array containing a salt and the cleartext value that appears in `privateData`. For example, to produce `Rfq.data.payin.paymentDetailsHash`, create a digest of `[salt, Rfq.privateData.payin.paymentDetails]`. The RECOMMENDED minimum length of the randomly-generated portion of the salt is 128 bits. The salt is placed in `privateData.salt`. The salt MUST be present when `privateData` is present.
 
@@ -480,9 +480,7 @@ This table enumerates the structure of
       "kind": "BTC_ADDRESS",
       "paymentDetailsHash": "<HASH_PRIVATE_PAYOUT_METHOD_PAYMENT_DETAILS>"
     },
-    "claimsHashes": [
-      "<HASH_PRIVATE_CLAIMS_0>"
-    ]
+    "claimsHash": "<HASH_PRIVATE_CLAIMS_0>"
   },
   "privateData": {
     "payin": {

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -365,7 +365,7 @@ Message kinds other than RFQ may NOT have property `privateData`. The [RFQ `priv
 {
   "data": {
     "offeringId": <OFFERING_ID>,
-    "claimsHashes": [<PRESENTATION_SUBMISSION_HASH>], <---- hash
+    "claimsHashes": [<VERIFIABLE_CREDENTIAL_HASH>], <---- hash
     "payin": {
       "kind": "BTC_ADDRESS",
       "amount": "STR_VALUE",
@@ -377,7 +377,7 @@ Message kinds other than RFQ may NOT have property `privateData`. The [RFQ `priv
     }
   },
   "privateData": {
-    "claims": [<PRESENTATION_SUBMISSION>], <---- actual
+    "claims": [<VERIFIABLE_CREDENTIAL>], <---- actual
     "payinMethod": {
       "paymentDetails": <OBJ> <---- actual
     },

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -354,17 +354,14 @@ The `metadata` object contains fields _about_ the message and is present in _eve
 The actual message content. This will _always_ be a JSON object. The [Message Kinds section](#message-kinds) specifies the content for each individual message type
 
 
-### `private`
-Often times, an RFQ will contain PII or PCI data either within the `credentials` being presented or within `paymentDetails` of `payinMethod` or `payoutMethod` (e.g. card details, phone numbers, full names etc). 
+### `privateData`
+Often times, an RFQ will contain PII or PCI data either within the `claims` being presented or within `paymentDetails` of `payin` or `payout` (e.g. card details, phone numbers, full names etc).
 
-In order to prevent storing this sensitive data with the message itself, the value of a property containing sensitive data can be a [hash](#Hashing) of the sensitive data. The actual sensitive data itself is included in the `private` field. 
+In order to prevent storing this sensitive data with the message itself, an RFQ may have property `privateData` which holds the raw values for certain fields, while the RFQ's `data` property holds salted hashes of the fields in `privateData`. `privateData` is NOT signed over, so the signature integrity of an RFQ can be verified even if `privateData` is not present. The hashed value is produced by creating a [digest](#digests) of a JSON array containing a salt and the cleartext value that appears in `privateData`. For example, to produce `Rfq.data.payin.paymentDetailsHash`, create a digest of `[salt, Rfq.privateData.payin.paymentDetails]`. The RECOMMENDED minimum length of the randomly-generated portion of the salt is 128 bits.
 
-The `private` field is ephemeral and **MUST** only be present when the message is initially sent to the intended recipient
+Message kinds other than RFQ may NOT have property `privateData`. The [RFQ `privateData` section](#rfq-request-for-quote) specifies the content of RFQ `data` and `privateData`.
 
-The value of `private` **MUST** be a JSON object that matches the structure of `data`. The properties present within `private` **MUST** only be the properties of `data` that include the hash counterpart.
-
-> **Note**
-> Rationale behind the `private` JSON object matching the structure of `data` is to simplify programmatic hash evaluation using JSONPath to pluck the respective hash from `data`. **NOTE**: we should try this to make sure it's actually "easy"
+The `privateData` field is ephemeral and **MUST** only be present when the message is initially sent to the intended recipient
 
 #### Example Usage in RFQ message
 
@@ -372,19 +369,19 @@ The value of `private` **MUST** be a JSON object that matches the structure of `
 {
   "data": {
     "offeringId": <OFFERING_ID>,
-    "payoutAmount": "STR_VALUE",
-    "claims": <PRESENTATION_SUBMISSION_HASH>, <---- hash
-    "payinMethod": {
+    "claimsHashes": [<PRESENTATION_SUBMISSION_HASH>], <---- hash
+    "payin": {
       "kind": "BTC_ADDRESS",
-      "paymentDetails": <OBJ_HASH> <---- hash
+      "amount": "STR_VALUE",
+      "paymentDetailsHash": <OBJ_HASH> <---- hash
     },
-    "payoutMethod": {
+    "payout": {
       "kind": "MOMO_MPESA",
-      "paymentDetails": <OBJ_HASH> <---- hash
+      "paymentDetailsHash": <OBJ_HASH> <---- hash
     }
   },
-  "private": {
-    "claims": <PRESENTATION_SUBMISSION>, <---- actual
+  "privateData": {
+    "claims": [<PRESENTATION_SUBMISSION>], <---- actual
     "payinMethod": {
       "paymentDetails": <OBJ> <---- actual
     },
@@ -414,25 +411,38 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
 ### `RFQ (Request For Quote)`
 > Alice -> PFI: "OK, that offering looks good. Give me a Quote against that Offering, and here is how much USD (payin currency) I want to trade for BTC (payout currency). Here are the credentials you're asking for, the payment method I intend to pay you USD with, and the payment method I expect you to pay me BTC in."
 
-| field        | data type                                        | required | description                                                                           |
-| ------------ | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------- |
-| `offeringId` | string                                           | Y        | Offering which Alice would like to get a quote for                                    |
-| `claims`     | string[]                                         | Y        | an array of claims that fulfill the requirements declared in an [Offering](#offering) |
-| `payin`      | [`SelectedPayinMethod`](#selectedpaymentmethod)  | Y        | selected payin amount, method, and details                                            |
-| `payout`     | [`SelectedPayoutMethod`](#selectedpaymentmethod) | Y        | selected payout method, and details                                                   |
+| field          | data type                                        | required | description                                                                |
+|----------------|--------------------------------------------------|----------|----------------------------------------------------------------------------|
+| `offeringId`   | string                                           | Y        | Offering which Alice would like to get a quote for                         |
+| `claimsHashes` | string[]                                         | Y        | an array of salted digests of the claims appearing in `privateDate.claims` |
+| `payin`        | [`SelectedPayinMethod`](#selectedpaymentmethod)  | Y        | selected payin amount, method, and details                                 |
+| `payout`       | [`SelectedPayoutMethod`](#selectedpaymentmethod) | Y        | selected payout method, and details                                        |
 
 #### `SelectedPayinMethod`
-| field            | data type                         | required | description                                                                                       |
-| ---------------- | --------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `amount`         | [`DecimalString`](#decimalstring) | Y        | Amount of payin currency you want in exchange for payout currency                                 |
-| `kind`           | string                            | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)                       |
-| `paymentDetails` | object                            | N        | An object containing the properties defined in an Offering's `requiredPaymentDetails` json schema |
+| field                | data type                         | required | description                                                                 |
+|----------------------|-----------------------------------|----------|-----------------------------------------------------------------------------|
+| `amount`             | [`DecimalString`](#decimalstring) | Y        | Amount of payin currency you want in exchange for payout currency           |
+| `kind`               | string                            | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`) |
+| `paymentDetailsHash` | string                            | N        | A salted digest of `privateData.payin.paymentDetails`                       |
 
 #### `SelectedPayoutMethod`
+| field                | data type | required | description                                                                 |
+|----------------------|-----------|----------|-----------------------------------------------------------------------------|
+| `kind`               | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`) |
+| `paymentDetailsHash` | object    | N        | A salted digest of `privateData.payout.paymentDetails`                       |
+
+#### `privateData`
+| field    | data type                                         | required | description                                                                           |
+|----------|---------------------------------------------------|----------|---------------------------------------------------------------------------------------|
+| `salt`   | string                                            | N        |                                                                                       |
+| `claims` | string[]                                          | N        | an array of claims that fulfill the requirements declared in an [Offering](#offering) |
+| `payin`  | [`PrivatePaymentDetails`](#privatepaymentdetails) | N        | A container for the unhashed `payin.paymentDetails`                                   |
+| `payout` | [`PrivatePaymentDetails`](#privatepaymentdetails) | N        | A container for the unhashed `payout.paymentDetails`                                  |
+
+#### `PrivatePaymentDetails`
 | field            | data type | required | description                                                                                       |
 | ---------------- | --------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `kind`           | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)                       |
-| `paymentDetails` | object    | N        | An object containing the properties defined in an Offering's `requiredPaymentDetails` json schema |
+| `paymentDetails` | object    | N        | An object containing the properties defined in an Offering's `requiredPaymentDetails` json schema. If `data.payin/payout.paymentDetailsHash` is omitted, then `privateData.payin/payout.paymentDetails` respectively must also be omitted. |
 
 #### RFQ example
 ```json
@@ -451,17 +461,17 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
     "payin": {
       "amount": "200.00",
       "kind": "DEBIT_CARD",
-      "paymentDetails": "<HASH_PRIVATE_PAYIN_METHOD_PAYMENT_DETAILS>"
+      "paymentDetailsHash": "<HASH_PRIVATE_PAYIN_METHOD_PAYMENT_DETAILS>"
     },
     "payout": {
       "kind": "BTC_ADDRESS",
-      "paymentDetails": "<HASH_PRIVATE_PAYOUT_METHOD_PAYMENT_DETAILS>"
+      "paymentDetailsHash": "<HASH_PRIVATE_PAYOUT_METHOD_PAYMENT_DETAILS>"
     },
-    "claims": [
+    "claimsHashes": [
       "<HASH_PRIVATE_CLAIMS_0>"
     ]
   },
-  "private": {
+  "privateData": {
     "payin": {
       "paymentDetails": {
         "cardNumber": "1234567890123456",
@@ -479,7 +489,7 @@ Currency amounts have type `DecimalString`, which is string containing a decimal
       "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtzNE41WGRyRTZWaWVKc2dIOFNNU1Jhdm1Ub3g3NFJxb3JvVzdiWnpCTFFCaSIsInN1YiI6ImRpZDprZXk6ejZNa3M0TjVYZHJFNlZpZUpzZ0g4U01TUmF2bVRveDc0UnFvcm9XN2JaekJMUUJpIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwiaWQiOiIxNjk0NjM2MzY4NDI5IiwidHlwZSI6IllvbG9DcmVkZW50aWFsIiwiaXNzdWVyIjoiZGlkOmtleTp6Nk1rczRONVhkckU2VmllSnNnSDhTTVNSYXZtVG94NzRScW9yb1c3Ylp6QkxRQmkiLCJpc3N1YW5jZURhdGUiOiIyMDIzLTA5LTEzVDIwOjE5OjI4LjQyOVoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDprZXk6ejZNa3M0TjVYZHJFNlZpZUpzZ0g4U01TUmF2bVRveDc0UnFvcm9XN2JaekJMUUJpIiwiYmVlcCI6ImJvb3AifX19.cejevPPHPGhajd1oP4nfLpxRMKm801BzPdqjm9pQikaMEnh1WZXrap2j_kALZN_PCUddNtW1R_YY18UoERRJBw"
     ]
   },
-  "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3M0TjVYZHJFNlZpZUpzZ0g4U01TUmF2bVRveDc0UnFvcm9XN2JaekJMUUJpI3o2TWtzNE41WGRyRTZWaWVKc2dIOFNNU1Jhdm1Ub3g3NFJxb3JvVzdiWnpCTFFCaSJ9..LpR3qNP6PiiACVQKdP68OqhZZY8MqNX96WFS6CzVzX7EgmSroY1WC_tAnQzOAI1pGofzoasEuU1-a2tUOyB_Cg"
+  "signature": "<SIGNATURE_OVER_METADATA_AND_DATA>"
 }
 ```
 


### PR DESCRIPTION
## Context
#274

Previously, we considered the concept of a top-level unstructured `private` property in RFQ, which would optionally contain the private data specified by the Offering, where corresponding Rfq.data would be hashed. This PR lays out a simplified design compared to what we had before.

## Motivation
> Often times, an RFQ will contain PII or PCI data either within the `claims` being presented or within `paymentDetails` of `payin` or `payout` (e.g. card details, phone numbers, full names etc).

It is useful to be able to detach private fields from the RFQ payload and still be able to verify message integrity. So we create a separate section for private data.

## Q&A
1. Why call it `privateData` when we used to call it `private`?
Since `private` is a reserved word in most programming languages, it was awkward to call the field `private` in some places and have to think of another name in other places.

2. Why not use SD-JWT?
SD-JWT is more complex than our use case requires. There are only a few fields that we need to selectively disclose in an RFQ. The design laid out in this PR takes some ideas from SD-JWT without needing to implement the rest of the kitchen sink.

## Test vectors
This PR updates the existing `parse-rfq` test vectors because the new design constitutes a breaking change to RFQ message structure. This PR also adds a net new test vector related to RFQs called `parse-rfq-omit-private-data`.

TODO: Support updated test vectors in at least two tbdex implementations
- [x] tbdex-js [PR](https://github.com/TBD54566975/tbdex-js/pull/215)
- [ ] tbdex-kt
- [ ] tbdex-swift