### PR TITLE
#298 - Updated references of ISO 3166 to ISO 4217

### DIFF
--- a/hosted/json-schemas/balance.schema.json
+++ b/hosted/json-schemas/balance.schema.json
@@ -6,7 +6,7 @@
     "additionalProperties": false,
     "currencyCode": {
       "type": "string",
-      "description": "ISO 3166 currency code string"
+      "description": "ISO 4217 currency code string"
     },
     "available": {
       "$ref": "definitions.json#/definitions/decimalString",

--- a/hosted/json-schemas/offering.schema.json
+++ b/hosted/json-schemas/offering.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "currencyCode": {
           "type": "string",
-          "description": "ISO 3166 currency code string"
+          "description": "ISO 4217 currency code string"
         },
         "min": {
           "$ref": "definitions.json#/definitions/decimalString",
@@ -75,7 +75,7 @@
       "properties": {
         "currencyCode": {
           "type": "string",
-          "description": "ISO 3166 currency code string"
+          "description": "ISO 4217 currency code string"
         },
         "min": {
           "$ref": "definitions.json#/definitions/decimalString",

--- a/hosted/json-schemas/quote.schema.json
+++ b/hosted/json-schemas/quote.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "currencyCode": {
           "type": "string",
-          "description": "ISO 3166 currency code string"
+          "description": "ISO 4217 currency code string"
         },
         "amount": {
           "$ref": "definitions.json#/definitions/decimalString",

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -123,7 +123,7 @@ An `Offering` is a resource created by a PFI to define requirements for a given 
 #### `PayinDetails`
 | field          | data type                         | required | description                                            |
 | -------------- | --------------------------------- | -------- | ------------------------------------------------------ |
-| `currencyCode` | string                            | Y        | ISO 3166 currency code string                          |
+| `currencyCode` | string                            | Y        | ISO 4217 currency code string                          |
 | `min`          | [`DecimalString`](#decimalstring) | N        | Minimum amount of currency that the offer is valid for |
 | `max`          | [`DecimalString`](#decimalstring) | N        | Maximum amount of currency that the offer is valid for |
 | `methods`      | [`PayinMethod[]`](#payinmethod)   | Y        | A list of payment methods to select from               |
@@ -131,7 +131,7 @@ An `Offering` is a resource created by a PFI to define requirements for a given 
 #### `PayoutDetails`
 | field          | data type                         | required | description                                            |
 | -------------- | --------------------------------- | -------- | ------------------------------------------------------ |
-| `currencyCode` | string                            | Y        | ISO 3166 currency code string                          |
+| `currencyCode` | string                            | Y        | ISO 4217 currency code string                          |
 | `min`          | [`DecimalString`](#decimalstring) | N        | Minimum amount of currency that the offer is valid for |
 | `max`          | [`DecimalString`](#decimalstring) | N        | Maximum amount of currency that the offer is valid for |
 | `methods`      | [`PayoutMethod[]`](#payoutmethod) | Y        | A list of payment methods to select from               |
@@ -293,7 +293,7 @@ A `Balance` is a protected resource used to communicate the amounts of each curr
 
 | field          | data type                         | required | description                                |
 | -------------- | --------------------------------- | -------- | ------------------------------------------ |
-| `currencyCode` | string                            | Y        | ISO 3166 currency code string              |
+| `currencyCode` | string                            | Y        | ISO 4217 currency code string              |
 | `available  `  | [`DecimalString`](#decimalstring) | Y        | The amount available to be transacted with |
 
 #### Example Balance
@@ -552,7 +552,7 @@ A `Close` can be sent by Alice _or_ the PFI at any point during the exchange, bu
 #### `QuoteDetails`
 | field                | data type                                   | required | description                                                                                               |
 | -------------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `currencyCode`       | string                                      | Y        | ISO 3166 currency code string                                                                             |
+| `currencyCode`       | string                                      | Y        | ISO 4217 currency code string                                                                             |
 | `amount`             | [`DecimalString`](#decimalstring)           | Y        | The amount of currency paid to the PFI or by the PFI excluding fees                                       |
 | `fee`                | [`DecimalString`](#decimalstring)           | N        | The amount paid in fees                                                                                   |
 | `paymentInstruction` | [`PaymentInstruction`](#paymentinstruction) | N        | Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link) |


### PR DESCRIPTION
ISO 3166 is country code and ISO 4217 is the currency code. ISO 4217 is what we want to use (see #298).