### PR TITLE
#312 - Removed query params for listing exchanges

### DIFF
--- a/specs/http-api/README.md
+++ b/specs/http-api/README.md
@@ -405,7 +405,7 @@ True
 ## List Exchanges
 
 ### Description
-Returns a list of exchange ids 
+Returns a list of exchange IDs 
 
 ### Endpoint
 `GET /exchanges`
@@ -420,12 +420,6 @@ True
 | `400: Bad Request` | `{ errors: Error[] }`    |
 | `404: Not Found`   | N/A                      |
 | `403: Forbidden`   | N/A                      |
-
-### Query Params
-
-| Param | Description              |
-| ----- | ------------------------ |
-| id    | exchange id(s) to return |
 
 ---
 


### PR DESCRIPTION
Query params of exchange IDs doesn't not make sense when are you are trying to fetch those IDs in the first place (see #312).