### PR TITLE
fix: use fragment in json schema refs

### DIFF
--- a/hosted/json-schemas/offering.schema.json
+++ b/hosted/json-schemas/offering.schema.json
@@ -47,7 +47,7 @@
                 "description": "Value that can be used to group specific payment methods together (e.g. Mobile Money vs. Direct Bank Deposit)."
               },
               "requiredPaymentDetails": {
-                "$ref": "http://json-schema.org/draft-07/schema",
+                "$ref": "http://json-schema.org/draft-07/schema#",
                 "description": "A JSON Schema containing the fields that need to be collected in order to use this payment method"
               },
               "min": {
@@ -108,7 +108,7 @@
                 "description": "Value that can be used to group specific payment methods together (e.g. Mobile Money vs. Direct Bank Deposit)."
               },
               "requiredPaymentDetails": {
-                "$ref": "http://json-schema.org/draft-07/schema",
+                "$ref": "http://json-schema.org/draft-07/schema#",
                 "description": "A JSON Schema containing the fields that need to be collected in order to use this payment method"
               },
               "min": {

--- a/hosted/test-vectors/protocol/vectors/parse-offering.json
+++ b/hosted/test-vectors/protocol/vectors/parse-offering.json
@@ -1,12 +1,12 @@
 {
   "description": "Offering parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:3whftgpbdjihx9ze9tdn575zqzm4qwccetnf1ybiibuzad7rrmyy\",\"kind\":\"offering\",\"id\":\"offering_01hw25hn26egjtzdyx107p005q\",\"createdAt\":\"2024-04-22T05:48:01.479Z\",\"protocol\":\"1.0\"},\"data\":{\"description\":\"Selling BTC for USD\",\"payin\":{\"currencyCode\":\"USD\",\"min\":\"0.0\",\"max\":\"999999.99\",\"methods\":[{\"kind\":\"DEBIT_CARD\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"cardNumber\":{\"type\":\"string\",\"description\":\"The 16-digit debit card number\",\"minLength\":16,\"maxLength\":16},\"expiryDate\":{\"type\":\"string\",\"description\":\"The expiry date of the card in MM/YY format\",\"pattern\":\"^(0[1-9]|1[0-2])\\\\/([0-9]{2})$\"},\"cardHolderName\":{\"type\":\"string\",\"description\":\"Name of the cardholder as it appears on the card\"},\"cvv\":{\"type\":\"string\",\"description\":\"The 3-digit CVV code\",\"minLength\":3,\"maxLength\":3}},\"required\":[\"cardNumber\",\"expiryDate\",\"cardHolderName\",\"cvv\"],\"additionalProperties\":false}}]},\"payout\":{\"currencyCode\":\"BTC\",\"max\":\"999526.11\",\"methods\":[{\"kind\":\"BTC_ADDRESS\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"btcAddress\":{\"type\":\"string\",\"description\":\"your Bitcoin wallet address\"}},\"required\":[\"btcAddress\"],\"additionalProperties\":false},\"estimatedSettlementTime\":10}]},\"payoutUnitsPerPayinUnit\":\"0.00003826\",\"requiredClaims\":{\"id\":\"7ce4004c-3c38-4853-968b-e411bafcd945\",\"input_descriptors\":[{\"id\":\"bbdb9b7c-5754-4f46-b63b-590bada959e0\",\"constraints\":{\"fields\":[{\"path\":[\"$.type[*]\"],\"filter\":{\"type\":\"string\",\"pattern\":\"^YoloCredential$\"}}]}}]}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M3doZnRncGJkamloeDl6ZTl0ZG41NzV6cXptNHF3Y2NldG5mMXliaWlidXphZDdycm15eSMwIn0..N9PpzD-8xCFQb6JZ63isyqk3GSOc3hkrbbqQD9CeCcoKZsEyhHHD-cMp8vTrJr5tPs3XqZB1zWJYGupqhoN-BA\"}",
+  "input": "{\"metadata\":{\"from\":\"did:dht:c765ni81pupn5zc646xskdsufgokstbsgfwhae8hudsrjushhruy\",\"kind\":\"offering\",\"id\":\"offering_01hwcg100gf8btevp8x3pea75b\",\"createdAt\":\"2024-04-26T06:03:34.289Z\",\"protocol\":\"1.0\"},\"data\":{\"description\":\"Selling BTC for USD\",\"payin\":{\"currencyCode\":\"USD\",\"min\":\"0.0\",\"max\":\"999999.99\",\"methods\":[{\"kind\":\"DEBIT_CARD\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"cardNumber\":{\"type\":\"string\",\"description\":\"The 16-digit debit card number\",\"minLength\":16,\"maxLength\":16},\"expiryDate\":{\"type\":\"string\",\"description\":\"The expiry date of the card in MM/YY format\",\"pattern\":\"^(0[1-9]|1[0-2])\\\\/([0-9]{2})$\"},\"cardHolderName\":{\"type\":\"string\",\"description\":\"Name of the cardholder as it appears on the card\"},\"cvv\":{\"type\":\"string\",\"description\":\"The 3-digit CVV code\",\"minLength\":3,\"maxLength\":3}},\"required\":[\"cardNumber\",\"expiryDate\",\"cardHolderName\",\"cvv\"],\"additionalProperties\":false}}]},\"payout\":{\"currencyCode\":\"BTC\",\"max\":\"999526.11\",\"methods\":[{\"kind\":\"BTC_ADDRESS\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"btcAddress\":{\"type\":\"string\",\"description\":\"your Bitcoin wallet address\"}},\"required\":[\"btcAddress\"],\"additionalProperties\":false},\"estimatedSettlementTime\":10}]},\"payoutUnitsPerPayinUnit\":\"0.00003826\",\"requiredClaims\":{\"id\":\"7ce4004c-3c38-4853-968b-e411bafcd945\",\"input_descriptors\":[{\"id\":\"bbdb9b7c-5754-4f46-b63b-590bada959e0\",\"constraints\":{\"fields\":[{\"path\":[\"$.type[*]\"],\"filter\":{\"type\":\"string\",\"pattern\":\"^YoloCredential$\"}}]}}]}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6Yzc2NW5pODFwdXBuNXpjNjQ2eHNrZHN1Zmdva3N0YnNnZndoYWU4aHVkc3JqdXNoaHJ1eSMwIn0..ciWPR5RGHxfQZJUKw3Z2np6EtVJ0wQMZBsNoFjJ-W11x1NmmZCfSkbRAES0eoGlu0Wlyf4waHKvN0UdunakgCw\"}",
   "output": {
     "metadata": {
-      "from": "did:dht:3whftgpbdjihx9ze9tdn575zqzm4qwccetnf1ybiibuzad7rrmyy",
+      "from": "did:dht:c765ni81pupn5zc646xskdsufgokstbsgfwhae8hudsrjushhruy",
       "kind": "offering",
-      "id": "offering_01hw25hn26egjtzdyx107p005q",
-      "createdAt": "2024-04-22T05:48:01.479Z",
+      "id": "offering_01hwcg100gf8btevp8x3pea75b",
+      "createdAt": "2024-04-26T06:03:34.289Z",
       "protocol": "1.0"
     },
     "data": {
@@ -102,7 +102,7 @@
         ]
       }
     },
-    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M3doZnRncGJkamloeDl6ZTl0ZG41NzV6cXptNHF3Y2NldG5mMXliaWlidXphZDdycm15eSMwIn0..N9PpzD-8xCFQb6JZ63isyqk3GSOc3hkrbbqQD9CeCcoKZsEyhHHD-cMp8vTrJr5tPs3XqZB1zWJYGupqhoN-BA"
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6Yzc2NW5pODFwdXBuNXpjNjQ2eHNrZHN1Zmdva3N0YnNnZndoYWU4aHVkc3JqdXNoaHJ1eSMwIn0..ciWPR5RGHxfQZJUKw3Z2np6EtVJ0wQMZBsNoFjJ-W11x1NmmZCfSkbRAES0eoGlu0Wlyf4waHKvN0UdunakgCw"
   },
   "error": false
 }

--- a/hosted/test-vectors/protocol/vectors/parse-offering.json
+++ b/hosted/test-vectors/protocol/vectors/parse-offering.json
@@ -1,6 +1,6 @@
 {
   "description": "Offering parses from string",
-  "input": "{\"metadata\":{\"from\":\"did:dht:3whftgpbdjihx9ze9tdn575zqzm4qwccetnf1ybiibuzad7rrmyy\",\"kind\":\"offering\",\"id\":\"offering_01hw25hn26egjtzdyx107p005q\",\"createdAt\":\"2024-04-22T05:48:01.479Z\",\"protocol\":\"1.0\"},\"data\":{\"description\":\"Selling BTC for USD\",\"payin\":{\"currencyCode\":\"USD\",\"min\":\"0.0\",\"max\":\"999999.99\",\"methods\":[{\"kind\":\"DEBIT_CARD\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema\",\"type\":\"object\",\"properties\":{\"cardNumber\":{\"type\":\"string\",\"description\":\"The 16-digit debit card number\",\"minLength\":16,\"maxLength\":16},\"expiryDate\":{\"type\":\"string\",\"description\":\"The expiry date of the card in MM/YY format\",\"pattern\":\"^(0[1-9]|1[0-2])\\\\/([0-9]{2})$\"},\"cardHolderName\":{\"type\":\"string\",\"description\":\"Name of the cardholder as it appears on the card\"},\"cvv\":{\"type\":\"string\",\"description\":\"The 3-digit CVV code\",\"minLength\":3,\"maxLength\":3}},\"required\":[\"cardNumber\",\"expiryDate\",\"cardHolderName\",\"cvv\"],\"additionalProperties\":false}}]},\"payout\":{\"currencyCode\":\"BTC\",\"max\":\"999526.11\",\"methods\":[{\"kind\":\"BTC_ADDRESS\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema\",\"type\":\"object\",\"properties\":{\"btcAddress\":{\"type\":\"string\",\"description\":\"your Bitcoin wallet address\"}},\"required\":[\"btcAddress\"],\"additionalProperties\":false},\"estimatedSettlementTime\":10}]},\"payoutUnitsPerPayinUnit\":\"0.00003826\",\"requiredClaims\":{\"id\":\"7ce4004c-3c38-4853-968b-e411bafcd945\",\"input_descriptors\":[{\"id\":\"bbdb9b7c-5754-4f46-b63b-590bada959e0\",\"constraints\":{\"fields\":[{\"path\":[\"$.type[*]\"],\"filter\":{\"type\":\"string\",\"pattern\":\"^YoloCredential$\"}}]}}]}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M3doZnRncGJkamloeDl6ZTl0ZG41NzV6cXptNHF3Y2NldG5mMXliaWlidXphZDdycm15eSMwIn0..N9PpzD-8xCFQb6JZ63isyqk3GSOc3hkrbbqQD9CeCcoKZsEyhHHD-cMp8vTrJr5tPs3XqZB1zWJYGupqhoN-BA\"}",
+  "input": "{\"metadata\":{\"from\":\"did:dht:3whftgpbdjihx9ze9tdn575zqzm4qwccetnf1ybiibuzad7rrmyy\",\"kind\":\"offering\",\"id\":\"offering_01hw25hn26egjtzdyx107p005q\",\"createdAt\":\"2024-04-22T05:48:01.479Z\",\"protocol\":\"1.0\"},\"data\":{\"description\":\"Selling BTC for USD\",\"payin\":{\"currencyCode\":\"USD\",\"min\":\"0.0\",\"max\":\"999999.99\",\"methods\":[{\"kind\":\"DEBIT_CARD\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"cardNumber\":{\"type\":\"string\",\"description\":\"The 16-digit debit card number\",\"minLength\":16,\"maxLength\":16},\"expiryDate\":{\"type\":\"string\",\"description\":\"The expiry date of the card in MM/YY format\",\"pattern\":\"^(0[1-9]|1[0-2])\\\\/([0-9]{2})$\"},\"cardHolderName\":{\"type\":\"string\",\"description\":\"Name of the cardholder as it appears on the card\"},\"cvv\":{\"type\":\"string\",\"description\":\"The 3-digit CVV code\",\"minLength\":3,\"maxLength\":3}},\"required\":[\"cardNumber\",\"expiryDate\",\"cardHolderName\",\"cvv\"],\"additionalProperties\":false}}]},\"payout\":{\"currencyCode\":\"BTC\",\"max\":\"999526.11\",\"methods\":[{\"kind\":\"BTC_ADDRESS\",\"requiredPaymentDetails\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"btcAddress\":{\"type\":\"string\",\"description\":\"your Bitcoin wallet address\"}},\"required\":[\"btcAddress\"],\"additionalProperties\":false},\"estimatedSettlementTime\":10}]},\"payoutUnitsPerPayinUnit\":\"0.00003826\",\"requiredClaims\":{\"id\":\"7ce4004c-3c38-4853-968b-e411bafcd945\",\"input_descriptors\":[{\"id\":\"bbdb9b7c-5754-4f46-b63b-590bada959e0\",\"constraints\":{\"fields\":[{\"path\":[\"$.type[*]\"],\"filter\":{\"type\":\"string\",\"pattern\":\"^YoloCredential$\"}}]}}]}},\"signature\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6M3doZnRncGJkamloeDl6ZTl0ZG41NzV6cXptNHF3Y2NldG5mMXliaWlidXphZDdycm15eSMwIn0..N9PpzD-8xCFQb6JZ63isyqk3GSOc3hkrbbqQD9CeCcoKZsEyhHHD-cMp8vTrJr5tPs3XqZB1zWJYGupqhoN-BA\"}",
   "output": {
     "metadata": {
       "from": "did:dht:3whftgpbdjihx9ze9tdn575zqzm4qwccetnf1ybiibuzad7rrmyy",
@@ -19,7 +19,7 @@
           {
             "kind": "DEBIT_CARD",
             "requiredPaymentDetails": {
-              "$schema": "http://json-schema.org/draft-07/schema",
+              "$schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "properties": {
                 "cardNumber": {
@@ -62,7 +62,7 @@
           {
             "kind": "BTC_ADDRESS",
             "requiredPaymentDetails": {
-              "$schema": "http://json-schema.org/draft-07/schema",
+              "$schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "properties": {
                 "btcAddress": {

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -202,7 +202,7 @@ Some payment methods should be consistent across PFIs and therefore have reserve
         {
           "kind": "DEBIT_CARD",
           "requiredPaymentDetails": {
-            "$schema": "http://json-schema.org/draft-07/schema",
+            "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": {
               "cardNumber": {
@@ -246,7 +246,7 @@ Some payment methods should be consistent across PFIs and therefore have reserve
           "kind": "BTC_ADDRESS",
           "estimatedSettlementTime": 3600,
           "requiredPaymentDetails": {
-            "$schema": "http://json-schema.org/draft-07/schema",
+            "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": {
               "btcAddress": {


### PR DESCRIPTION
closes https://github.com/TBD54566975/tbdex/issues/311

- this pr maintains consistency throughout the spec and hosted vectors / json schemas regarding the fragment identifier `#` in the urls for draft 7 of json schema