### PR TITLE
Add Justfile to copy schemas to .schemas/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 js/src/try.ts
 *.log
+.schemas/

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+set positional-arguments
+
+_help:
+  @just -l
+
+schemas:
+  #!/bin/bash
+  set -euo pipefail
+  
+  source_dir="hosted/json-schemas" 
+  dest_dir=".schemas"
+
+  mkdir -p $dest_dir
+  rm -rf $dest_dir/*
+  cp -R $source_dir/* $dest_dir/
+  echo "Schema files successfully copied to $dest_dir/"


### PR DESCRIPTION
Context: [TBD Schema Hosting](https://github.com/TBD54566975/schemas/issues/1)

This PR will:
- Add a `just schemas` command that will copy tbDEX JSON schemas to a `.schemas/` directory.

closes #352