### PR TITLE
Introduce spec implementation tests

### DIFF
--- a/.github/workflows/test-implementations.yml
+++ b/.github/workflows/test-implementations.yml
@@ -1,0 +1,96 @@
+name: Test Implementation Repos
+
+on:
+  push:
+    branches:
+      - main
+      - leordev/test-implementations
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: tbdex-js
+            ci_file: integrity-check.yml
+            spec_path: tbdex
+          - repo: tbdex-swift
+            ci_file: ci.yml
+            spec_path: Tests/tbDEXTestVectors/tbdex-spec
+          - repo: tbdex-kt
+            ci_file: ci.yml
+            spec_path: tbdex
+          - repo: tbdex-rs
+            ci_file: ci.yml
+            spec_path: tbdex
+
+    runs-on: ubuntu-latest
+    steps:  
+      - name: Generate an access token to write to downstream repo
+        uses: actions/create-github-app-token@2986852ad836768dfea7781f31828eb3e17990fa # v1.6.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.CICD_ROBOT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.CICD_ROBOT_GITHUB_APP_PRIVATE_KEY }}
+          owner: TBD54566975
+          repositories: ${{ matrix.repo }}
+
+      - name: Checkout spec repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: TBD54566975/${{ matrix.repo }}
+          ref: main
+          submodules: true
+          # persist-credentials: false
+
+      - name: Setup Spec values
+        id: spec-vals
+        env:
+          SPEC_SHA: ${{ github.event.head_commit.id }}
+        run: |
+          SHORT_SHA=$(echo ${{ env.SPEC_SHA }} | cut -c 1-7)
+          echo "SPEC_SHORT_SHA=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "SPEC_SHA=${{ env.SPEC_SHA }}" >> $GITHUB_OUTPUT
+          echo "SPEC_REF=tbd-ci-cd-robot/spec-tests" >> $GITHUB_OUTPUT
+
+      - name: Update spec submodule in ${{ matrix.repo }}
+        env:
+          SPEC_SHORT_SHA: ${{ steps.spec-vals.outputs.SPEC_SHORT_SHA }}
+          SPEC_SHA: ${{ steps.spec-vals.outputs.SPEC_SHA }}
+          SPEC_REF: ${{ steps.spec-vals.outputs.SPEC_REF }}
+        run: |
+          REPO_ROOT=$(pwd)
+          cd ${{ matrix.spec_path }}
+          git fetch origin ${{ env.SPEC_SHA }}
+          git checkout ${{ env.SPEC_SHA }}
+          cd $REPO_ROOT
+          git checkout -b ${{ env.SPEC_REF }}
+          git add .
+          git config user.name "tbd-ci-cd-robot[bot]"
+          git config user.email "${{ secrets.CICD_ROBOT_GITHUB_APP_ID }}+tbd-ci-cd-robot[bot]@users.noreply.github.com"
+          git commit -m "Update tbdex spec to ${{ env.SPEC_SHORT_SHA }}"
+          git push origin ${{ env.SPEC_REF }} -f
+
+      - name: Trigger and wait for ${{ matrix.repo }} CI pipeline
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: TBD54566975
+          repo: ${{ matrix.repo }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          workflow_file_name: ${{ matrix.ci_file }}
+          ref: ${{ steps.spec-vals.outputs.SPEC_REF }}
+          wait_interval: 10
+          # client_payload: '{}'
+          # propagate_failure: false
+          # trigger_workflow: true
+          # wait_workflow: true
+      
+      # TODO: 
+      # - make the pipeline ignore failures so devs dont ignore the CI checks
+      # - add a step to add a comment summary with the failures in the PR, so PRs can act accordingly
+      # - add a step to automate issue creation for each failure (or update existing one)


### PR DESCRIPTION
(wip draft, don't merge it yet)

**Stage 1:**
- [ ] Run tests on the children specs implementation languages for new Spec PRs
- [ ] Report it back in this Spec PR as a comment

**Stage 2:**
- [ ] Scheduled run on the children specs repo, like in a daily basis
- [ ] If failure aggregate the results in an issue
- [ ] Each run is logged in that issue with the failed spec repo version

**Stage 3:**
- [ ] Improve notification: should it go to Discord/Slack/Email/etc?