### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sequenceDiagram
     deactivate PFI
 ```
 
-For information on the development process for this protocol, check out [sdk-development](https://github.com/TBD54566975/sdk-development/)
+For information on the development process for this protocol, check out [sdk-development](https://github.com/TBD54566975/sdk-development/).
 
 ## Implementations
 
@@ -58,6 +58,8 @@ Implementations are run against a common set of [test vectors](./hosted/test-vec
 
 
 ## Features
+
+A hosted set of the JSON schemas are also availbled on the [hosted site](https://tbdex.dev/).
 
 ### tbDEX Message
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@
 ## Purpose
 This repo contains specifications for tbDEX
 
-
-| Specification                 | Description                                                                                          | Status                               |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| [Protocol](./specs/protocol/) | Defines the message and resource formats that make up the tbDEX messaging protocol                   | [Draft](./specs/protocol/#status-) |
-| [HTTP API](./specs/http-api/) | Defines a REST API that can be hosted by an individual PFI that wants to provide liquidity via tbDEX | [Draft](./specs/http-api/#status-) |
+| **Specification**                 | **Description**                                                                                          | **Status**                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| [Protocol](./specs/protocol/)     | Defines the message and resource formats that make up the tbDEX messaging protocol                       | [Draft](./specs/protocol/#status-)       |
+| [HTTP API](./specs/http-api/)     | Defines a REST API that can be hosted by an individual PFI that wants to provide liquidity via tbDEX     | [Draft](./specs/http-api/#status-)       |
 
 ```mermaid
 sequenceDiagram
@@ -40,10 +39,10 @@ sequenceDiagram
 
 For information on the development process for this protocol, check out [sdk-development](https://github.com/TBD54566975/sdk-development/)
 
-## Implementations 
+## Implementations
 
-* [JavaScript/Typescript](https://github.com/TBD54566975/tbdex-js) 
-* [Kotlin](https://github.com/TBD54566975/tbdex-kt) 
+* [JavaScript/Typescript](https://github.com/TBD54566975/tbdex-js)
+* [Kotlin](https://github.com/TBD54566975/tbdex-kt)
 * [Swift](https://github.com/TBD54566975/tbdex-swift) (only supports client-side)
 
 ### Tooling
@@ -62,101 +61,101 @@ Implementations are run against a common set of [test vectors](./hosted/test-vec
 
 ### tbDEX Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Validation   | ✅         | ✅     | ✅   | ❌    |
-| Signing      | ✅         | ✅     | ✅   | ❌    |
-| Verification | ✅         | ✅     | ✅   | ❌    |
-| Parsing      | ✅         | ✅     | ✅   | ❌    |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Validation    | ✅             | ✅         | ✅        | ❌       |
+| Signing       | ✅             | ✅         | ✅        | ❌       |
+| Verification  | ✅             | ✅         | ✅        | ❌       |
+| Parsing       | ✅             | ✅         | ✅        | ❌       |
 
 ### tbDEX Resource
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Validation   | ✅          | ✅      | ❌    | ❌     |
-| Signing      | ✅          | ✅      | ❌    | ❌     |
-| Verification | ✅          | ✅      | ❌    | ❌     |
-| Parsing      | ✅          | ✅      | ❌    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Validation    | ✅             | ✅         | ❌        | ❌       |
+| Signing       | ✅             | ✅         | ❌        | ❌       |
+| Verification  | ✅             | ✅         | ❌        | ❌       |
+| Parsing       | ✅             | ✅         | ❌        | ❌       |
 
 ### tbDEX Offering Resource
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ❌    | ❌     |
-| Validation   | ✅          | ✅      | ❌    | ❌     |
-| Signing      | ✅          | ✅      | ❌    | ❌     |
-| Verification | ✅          | ✅      | ❌    | ❌     |
-| Parsing      | ✅          | ✅      | ❌    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ❌        | ❌       |
+| Validation    | ✅             | ✅         | ❌        | ❌       |
+| Signing       | ✅             | ✅         | ❌        | ❌       |
+| Verification  | ✅             | ✅         | ❌        | ❌       |
+| Parsing       | ✅             | ✅         | ❌        | ❌       |
 
 ### tbDEX RFQ Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ✅    | ❌     |
-| Validation   | ✅          | ✅      | ✅    | ❌     |
-| Signing      | ✅          | ✅      | ✅    | ❌     |
-| Verification | ✅          | ✅      | ✅    | ❌     |
-| Parsing      | ✅          | ✅      | ✅    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ✅        | ❌       |
+| Validation    | ✅             | ✅         | ✅        | ❌       |
+| Signing       | ✅             | ✅         | ✅        | ❌       |
+| Verification  | ✅             | ✅         | ✅        | ❌       |
+| Parsing       | ✅             | ✅         | ✅        | ❌       |
 
 ### tbDEX Quote Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ❌    | ❌     |
-| Validation   | ✅          | ✅      | ❌    | ❌     |
-| Signing      | ✅          | ✅      | ❌    | ❌     |
-| Verification | ✅          | ✅      | ❌    | ❌     |
-| Parsing      | ✅          | ✅      | ❌    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ❌        | ❌       |
+| Validation    | ✅             | ✅         | ❌        | ❌       |
+| Signing       | ✅             | ✅         | ❌        | ❌       |
+| Verification  | ✅             | ✅         | ❌        | ❌       |
+| Parsing       | ✅             | ✅         | ❌        | ❌       |
 
 ### tbDEX Order Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ✅    | ❌     |
-| Validation   | ✅          | ✅      | ✅    | ❌     |
-| Signing      | ✅          | ✅      | ✅    | ❌     |
-| Verification | ✅          | ✅      | ✅    | ❌     |
-| Parsing      | ✅          | ✅      | ✅    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ✅        | ❌       |
+| Validation    | ✅             | ✅         | ✅        | ❌       |
+| Signing       | ✅             | ✅         | ✅        | ❌       |
+| Verification  | ✅             | ✅         | ✅        | ❌       |
+| Parsing       | ✅             | ✅         | ✅        | ❌       |
 
 ### tbDEX Order-Status Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ❌    | ❌     |
-| Validation   | ✅          | ✅      | ❌    | ❌     |
-| Signing      | ✅          | ✅      | ❌    | ❌     |
-| Verification | ✅          | ✅      | ❌    | ❌     |
-| Parsing      | ✅          | ✅      | ❌    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ❌        | ❌       |
+| Validation    | ✅             | ✅         | ❌        | ❌       |
+| Signing       | ✅             | ✅         | ❌        | ❌       |
+| Verification  | ✅             | ✅         | ❌        | ❌       |
+| Parsing       | ✅             | ✅         | ❌        | ❌       |
 
 ### tbDEX Close Message
 
-| Feature      | Typescript | Kotlin | Swift | Rust |
-| ------------ | ---------- | ------ | ---- | ----- |
-| Creation     | ✅          | ✅      | ✅    | ❌     |
-| Validation   | ✅          | ✅      | ✅    | ❌     |
-| Signing      | ✅          | ✅      | ✅    | ❌     |
-| Verification | ✅          | ✅      | ✅    | ❌     |
-| Parsing      | ✅          | ✅      | ✅    | ❌     |
+| **Feature**   | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------- | -------------- | ---------- | --------- | -------- |
+| Creation      | ✅             | ✅         | ✅        | ❌       |
+| Validation    | ✅             | ✅         | ✅        | ❌       |
+| Signing       | ✅             | ✅         | ✅        | ❌       |
+| Verification  | ✅             | ✅         | ✅        | ❌       |
+| Parsing       | ✅             | ✅         | ✅        | ❌       |
 
 ### tbDEX Client
 
-| Feature       | Typescript | Kotlin | Swift | Rust |
-| ------------- | ---------- | ------ | ---- | ----- |
-| Send Message  | ✅          | ✅      | ✅    | ❌     |
-| Get Exchange  | ✅          | ✅      | ✅    | ❌     |
-| Get Exchanges | ✅          | ✅      | ✅    | ❌     |
-| Get Offerings | ✅          | ✅      | ✅    | ❌     |
+| **Feature**       | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ----------------- | -------------- | ---------- | --------- | -------- |
+| Send Message      | ✅             | ✅         | ✅        | ❌       |
+| Get Exchange      | ✅             | ✅         | ✅        | ❌       |
+| Get Exchanges     | ✅             | ✅         | ✅        | ❌       |
+| Get Offerings     | ✅             | ✅         | ✅        | ❌       |
 
 ### tbDEX Server
 
-| Feature               | Typescript | Kotlin | Swift | Rust |
-| --------------------- | ---------- | ------ | ---- | ----- |
-| Get Exchange Handler  | ✅          | ✅      | ❌    | ❌     |
-| Get Exchanges Handler | ✅          | ✅      | ❌    | ❌     |
-| Get Offerings Handler | ✅          | ✅      | ❌    | ❌     |
-| Submit RFQ Handler    | ✅          | ✅      | ❌    | ❌     |
-| Submit Order Handler  | ✅          | ✅      | ❌    | ❌     |
-| Submit Close Handler  | ✅          | ✅      | ❌    | ❌     |
+| **Feature**               | **Typescript** | **Kotlin** | **Swift** | **Rust** |
+| ------------------------- | -------------- | ---------- | --------- | -------- |
+| Get Exchange Handler      | ✅             | ✅         | ❌        | ❌       |
+| Get Exchanges Handler     | ✅             | ✅         | ❌        | ❌       |
+| Get Offerings Handler     | ✅             | ✅         | ❌        | ❌       |
+| Submit RFQ Handler        | ✅             | ✅         | ❌        | ❌       |
+| Submit Order Handler      | ✅             | ✅         | ❌        | ❌       |
+| Submit Close Handler      | ✅             | ✅         | ❌        | ❌       |
 
 ## Documentation
 


### PR DESCRIPTION
This is a cosmetic PR since the tables weren't monospaced aligned. Additionally, this adds the hosted https://tbdex.dev site (which is already indexed and publicly available).